### PR TITLE
Carousel tweaks

### DIFF
--- a/components/Carousel.js
+++ b/components/Carousel.js
@@ -7,35 +7,36 @@ import _throttle from 'lodash/throttle'
 
 import Markdown from './Markdown'
 import portraitPropTypes from '../propTypes/portrait'
-import { bodyText, rem } from '../styling/typography'
+import { bodyText, rem, subsectionTitleText } from '../styling/typography'
 import { jpgCompression } from '../utils/constants'
 import ConditionalContainer from './ConditionalContainer'
 import { mdBreakpoint } from '../styling/breakpoints'
 
-const H3 = styled.h3`
-  font-weight: bold;
-  color: white;
-`
-
 const CarouselTextContainer = styled.div`
-  padding: 3rem;
+  ${bodyText}
+  padding: 3.5rem 3rem;
   color: white;
-
-  h3 {
-    text-align: left;
-    margin-bottom: 2rem;
-  }
 
   p {
-    ${bodyText}
     color: white;
-    margin: 0 0 2rem 0;
+    margin: 0 0 1.5rem 0;
+  }
+
+  p:last-child {
+    margin-bottom: 0;
   }
 
   @media (min-width: ${mdBreakpoint}) {
     // Don't let the text run into the next-slide button
     padding-right: calc(70px + 1rem);
   }
+`
+
+const CarouselTextTitle = styled.p`
+  ${subsectionTitleText}
+  color: white;
+  font-weight: bold;
+  text-align: left;
 `
 
 const Image = styled.div`
@@ -174,7 +175,7 @@ class MasifundeCarousel extends Component {
               <Image className="d-none d-md-block col-md-4 col-lg-3" src={`${item.image.url}?q=${jpgCompression}`} alt={item.image.title} />
               <MobileImage className="d-md-none p-0 w-100 h-100" src={`${item.image.url}?q=${jpgCompression}`} alt={item.image.title} />
               <CarouselTextContainer className="col-md-8 col-lg-9">
-                <H3>{item.heading}</H3>
+                <CarouselTextTitle>{item.heading}</CarouselTextTitle>
                 <Markdown source={item.text} />
               </CarouselTextContainer>
             </SlideRow>


### PR DESCRIPTION
__Based on #50.__

Tweaks the font sizes and spacing a bit. Next-slide button doesn't overlap with the text anymore in the medium and large versions.

__Excluded:__ indenting the text, increasing the first paragraph's size.