### PR TITLE
Subtitle texts aligned left by default.

### DIFF
--- a/styling/typography.js
+++ b/styling/typography.js
@@ -71,6 +71,7 @@ export const sectionTitleText = css`
 
 export const subsectionTitleText = css`
   ${titleText}
+  text-align: left;
   color: ${theme.pineCone};
   font-size: ${rem('26px')};
   font-weight: 500;


### PR DESCRIPTION
In the designs subtitles are generally left-aligned.