### PR TITLE
Show YouTube video titles in embed

### DIFF
--- a/components/YouTubeVideo.js
+++ b/components/YouTubeVideo.js
@@ -24,7 +24,7 @@ const VideoIframeContainer = ({
   return (
     <div className={className}>
       <VideoIframe
-        src={`https://www.youtube.com/embed/${videoId}?rel=0&amp;showinfo=0`}
+        src={`https://www.youtube.com/embed/${videoId}?rel=0&amp;showinfo=1`}
         frameBorder="0"
         allowFullScreen
       />


### PR DESCRIPTION
Change the showinfo youtube query param to true. This makes the youtube embed iframe display the title of the video