### PR TITLE
Convert ConditionalContainer to React component to avoid PropType error.

### DIFF
--- a/components/ConditionalContainer.js
+++ b/components/ConditionalContainer.js
@@ -1,7 +1,8 @@
+import React from 'react'
 import styled from 'styled-components'
-import { Container } from 'reactstrap'
+import PropTypes from 'prop-types'
 
-const ConditionalContainer = styled(Container)`
+const Div = styled.div`
   @media (max-width: ${(props) => {
     switch (props.containAfter) {
       case 'xs':
@@ -23,5 +24,16 @@ const ConditionalContainer = styled(Container)`
     max-width: 100%;
   }
 `
+
+const ConditionalContainer = ({ children, containAfter }) => (
+  <Div className="container" containAfter={containAfter}>
+    {children}
+  </Div>
+)
+
+ConditionalContainer.propTypes = {
+  children: PropTypes.node.isRequired,
+  containAfter: PropTypes.string.isRequired,
+}
 
 export default ConditionalContainer


### PR DESCRIPTION
[React's unknown prop error](https://reactjs.org/warnings/unknown-prop.html) said that the prop ```containAfter``` on ```ConditionalContainer``` should be removed. Before this PR the ```ConditionalContainer ```was just a styled component, meaning it just passed down all its props to the DOM element, rendering it with ```containafter``` as an attribute.
See https://github.com/styled-components/styled-components/issues/1198#issuecomment-336628848 and https://github.com/styled-components/styled-components/issues/305#issuecomment-266197867 for explanation on why this is.