### PR TITLE
Support iPhone X landscape mode

### DIFF
--- a/components/Layout.js
+++ b/components/Layout.js
@@ -78,7 +78,7 @@ const Layout = ({ headerData, children, footerData }) => (
   <ThemeProvider theme={theme}>
     <Fragment>
       <Head>
-        <meta name="viewport" content="width=device-width, initial-scale=1" />
+        <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
         <link rel="shortcut icon" type="image/x-icon" href="/static/favicon/favicon.ico" />
         <link rel="icon" type="image/png" href="/static/favicon/favicon-32x32.png" sizes="32x32" />
         <link rel="icon" type="image/png" href="/static/favicon/favicon-16x16.png" sizes="16x16" />


### PR DESCRIPTION
Changed the meta viewport-fit to 'cover'.
This lets us properly support iPhone X landscape mode.