### PR TITLE
Reload page on version update

### DIFF
--- a/components/Layout.js
+++ b/components/Layout.js
@@ -6,6 +6,7 @@ import _flow from 'lodash/flow'
 
 import withAnalytics from './withAnalytics'
 import withLoadingIndicator from './withLoadingIndicator'
+import withReloadOnUpdate from './withReloadOnUpdate'
 import Header, { propTypes as headerPropTypes } from './Header'
 import Footer, { propTypes as footerPropTypes } from './Footer'
 import { bodyText, pageTitleText, sectionTitleText, subsectionTitleText, rootFontSize } from '../styling/typography'
@@ -105,4 +106,8 @@ Layout.propTypes = {
   footerData: PropTypes.shape(footerPropTypes).isRequired,
 }
 
-export default _flow(withLoadingIndicator, withAnalytics)(Layout)
+export default _flow(
+  withLoadingIndicator,
+  withAnalytics,
+  withReloadOnUpdate,
+)(Layout)

--- a/components/withLoadingIndicator.js
+++ b/components/withLoadingIndicator.js
@@ -1,9 +1,13 @@
 import React from 'react'
 import NProgress from 'nprogress'
-import Router from 'next/router'
 import { injectGlobal } from 'styled-components'
 
 import theme from '../styling/theme'
+import {
+  onRouteChangeStart,
+  onRouteChangeComplete,
+  onRouteChangeError,
+} from '../utils/routerEvents'
 
 const PROGRESS_COLOR = theme.orangeRed
 
@@ -15,16 +19,16 @@ injectGlobal`
 
   #nprogress .bar {
     background: ${PROGRESS_COLOR};
-  
+
     position: fixed;
     z-index: 1031;
     top: 0;
     left: 0;
-  
+
     width: 100%;
     height: 2px;
   }
-  
+
   /* Fancy blur effect */
   #nprogress .peg {
     display: block;
@@ -34,12 +38,12 @@ injectGlobal`
     height: 100%;
     box-shadow: 0 0 10px ${PROGRESS_COLOR}, 0 0 5px ${PROGRESS_COLOR};
     opacity: 1.0;
-  
+
     -webkit-transform: rotate(3deg) translate(0px, -4px);
         -ms-transform: rotate(3deg) translate(0px, -4px);
             transform: rotate(3deg) translate(0px, -4px);
   }
-  
+
   /* Remove these to get rid of the spinner */
   #nprogress .spinner {
     display: block;
@@ -48,31 +52,31 @@ injectGlobal`
     top: 15px;
     right: 15px;
   }
-  
+
   #nprogress .spinner-icon {
     width: 18px;
     height: 18px;
     box-sizing: border-box;
-  
+
     border: solid 2px transparent;
     border-top-color: ${PROGRESS_COLOR};
     border-left-color: ${PROGRESS_COLOR};
     border-radius: 50%;
-  
+
     -webkit-animation: nprogress-spinner 400ms linear infinite;
             animation: nprogress-spinner 400ms linear infinite;
   }
-  
+
   .nprogress-custom-parent {
     overflow: hidden;
     position: relative;
   }
-  
+
   .nprogress-custom-parent #nprogress .spinner,
   .nprogress-custom-parent #nprogress .bar {
     position: absolute;
   }
-  
+
   @-webkit-keyframes nprogress-spinner {
     0%   { -webkit-transform: rotate(0deg); }
     100% { -webkit-transform: rotate(360deg); }
@@ -88,9 +92,9 @@ NProgress.configure({
   trickleSpeed: 100,
 })
 
-Router.onRouteChangeStart = () => NProgress.start()
-Router.onRouteChangeComplete = () => NProgress.done()
-Router.onRouteChangeError = () => NProgress.done()
+onRouteChangeStart(() => NProgress.start())
+onRouteChangeComplete(() => NProgress.done())
+onRouteChangeError(() => NProgress.done())
 
 const withLoaderIndicator = (WrappedComponent) => {
   const LoadingIndicatorWrapper = props => (

--- a/components/withReloadOnUpdate.js
+++ b/components/withReloadOnUpdate.js
@@ -1,0 +1,68 @@
+import React, { Component } from 'react'
+
+import {
+  onAppUpdated,
+  onRouteChangeStart,
+  onRouteChangeComplete,
+  onRouteChangeError,
+} from '../utils/routerEvents'
+
+function reloadPage(nextUrl) {
+  window.location.href = nextUrl
+}
+
+/**
+ * Prevents route changes from silently failing if a new version of the
+ * website was deployed while a user still has the previous version open.
+ * The failure is due to Next.js' "build ID" mechanism, which prevents one
+ * website version to load code chunks from another version because of
+ * possible incompatibilities. See the explanation on the Next.js wiki:
+ *
+ * https://github.com/zeit/next.js/wiki/Deployment
+ *
+ * This wrapper component handles these failures by doing a full reload
+ * with the target page URL, "upgrading" the user to the new version. From
+ * the user's perspective, this will appear pretty much like an ordinary
+ * (if less snappy) page load.
+ */
+export default function withReloadOnUpdate(WrappedComponent) {
+  class ReloadOnSiteUpdate extends Component {
+    componentDidMount() {
+      // Theoretically, this should be everything that's needed to reload the
+      // page once the site's version changed. However, there is currently
+      // (v4.2.1) a bug in Next.js that prevents this this not work for
+      // static HTML exports:
+      //
+      // https://github.com/zeit/next.js/issues/3558
+      //
+      // The code is still here for the case that the problem gets fixed on the
+      // Next.js side. Then it should Just Work.
+      onAppUpdated((url) => {
+        reloadPage(url)
+      })
+
+      // As a workaround for the bug above, we try to detect version-related
+      // route change failures with a timeout. If the route change does not
+      // complete in a few seconds, we assume that the target page's code
+      // chunk has disappeard (because there is a newer version with a new
+      // build ID, hence different file paths). We then reload with the
+      // target pages' URL.
+
+      const reloadTimeout = 5000 // ms
+      let reloadTimeoutId = null
+
+      onRouteChangeStart((url) => {
+        reloadTimeoutId = setTimeout(() => reloadPage(url), reloadTimeout)
+      })
+
+      onRouteChangeComplete(() => clearTimeout(reloadTimeoutId))
+      onRouteChangeError(() => clearTimeout(reloadTimeoutId))
+    }
+
+    render() {
+      return <WrappedComponent {...this.props} />
+    }
+  }
+
+  return ReloadOnSiteUpdate
+}

--- a/utils/routerEvents.js
+++ b/utils/routerEvents.js
@@ -1,0 +1,47 @@
+import Router from 'next/router'
+
+// Next.js allows only a single listener for every router event:
+// https://github.com/zeit/next.js/issues/2033
+//
+// To overcome this limitation, this module binds all router events to
+// simple listeners which simply multiplex these to as many sub-listeners
+// as needed.
+
+const listeners = {
+  routeChangeStart: [],
+  routeChangeComplete: [],
+  routeChangeError: [],
+  appUpdated: [],
+}
+
+export function onRouteChangeStart(listener) {
+  listeners.routeChangeStart.push(listener)
+}
+
+export function onRouteChangeComplete(listener) {
+  listeners.routeChangeComplete.push(listener)
+}
+
+export function onRouteChangeError(listener) {
+  listeners.routeChangeError.push(listener)
+}
+
+export function onAppUpdated(listener) {
+  listeners.appUpdated.push(listener)
+}
+
+const makeMultiListener = subListeners => (...args) => {
+  subListeners.forEach((listener) => {
+    try {
+      listener(...args)
+    } catch (error) {
+      // eslint-disable-next-line no-console
+      console.error(error)
+    }
+  })
+}
+
+Router.onRouteChangeStart = makeMultiListener(listeners.routeChangeStart)
+Router.onRouteChangeComplete = makeMultiListener(listeners.routeChangeComplete)
+Router.onRouteChangeError = makeMultiListener(listeners.routeChangeError)
+Router.onAppUpdated = makeMultiListener(listeners.appUpdated)


### PR DESCRIPTION
This is normally done by Next.js automatically, but is apparently not working for statically exported pages, causing the site to get stuck when trying to follow a link after the website has been updated in the background.

https://github.com/zeit/next.js/issues/3558

As a workaround, we speculatively do a full reload five seconds after a route change has started but not completed. To the user, this will seem like just a particularly long page load.