### PR TITLE
Use qs as the sole query-string library

### DIFF
--- a/api/common.js
+++ b/api/common.js
@@ -1,6 +1,7 @@
+import qs from 'qs'
+
 import { fetchMemoizedSingleEntry } from './contentfulService'
 import { jpegQuality } from '../utils/constants'
-import makeQueryString from '../utils/makeQueryString'
 
 export async function fetchHeaderData(locale) {
   return fetchMemoizedSingleEntry('header', locale)
@@ -22,7 +23,7 @@ export const unwrapImage = (image, urlParams) => {
     }
   }
 
-  const urlQuery = urlParams ? `?${makeQueryString(urlParams)}` : ''
+  const urlQuery = urlParams ? `?${qs.stringify(urlParams)}` : ''
 
   return {
     url: imageFile.url + urlQuery,

--- a/components/Fundraisingbox/FundRaisingIframe.js
+++ b/components/Fundraisingbox/FundRaisingIframe.js
@@ -1,6 +1,6 @@
 import React, { Component, Fragment } from 'react'
 import ReactAsyncScript from 'react-async-script'
-import { stringify } from 'query-string'
+import qs from 'qs'
 import PropTypes from 'prop-types'
 
 let intervalRef = null
@@ -99,7 +99,7 @@ function ScriptParametersWrapper({
     wants_newsletter: wantsNewsletter,
     wants_receipt: wantsReceipt,
   }
-  const FullUrl = `${BaseUrl}?${stringify(parameters)}`
+  const FullUrl = `${BaseUrl}?${qs.stringify(parameters)}`
 
   const Form = ReactAsyncScript(FundRaisingIframe, FullUrl, {
     globalName: 'FundRaisingBox',

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "nuka-carousel": "^3.0.0",
     "polished": "^1.9.0",
     "prop-types": "^15.6.0",
+    "qs": "^6.5.1",
     "react": "^16.2.0",
     "react-async-script": "^0.9.1",
     "react-dom": "^16.2.0",

--- a/utils/makeQueryString.js
+++ b/utils/makeQueryString.js
@@ -1,5 +1,0 @@
-export default function makeQueryString(params) {
-  return Object.keys(params)
-    .map(key => `${key}=${encodeURIComponent(params[key])}`)
-    .join('&')
-}


### PR DESCRIPTION
This removes the dependency on `query-string` and the custom query string function for reduced maintenance. `qs` is required by the Contentful SDK anyway, so there is no growth in bundle
size. (In fact, it shrinks ever-so-slightly because our implementation is gone now.)

The reason I didn't trust our simple version is that where `query-string` was used before, we are processing user inputs. I felt more confident letting `qs` ensure this is secure.