### PR TITLE
Add padding to the bottom of fundraisingform iframe

### DIFF
--- a/Fundraisingbox_custom_css.css
+++ b/Fundraisingbox_custom_css.css
@@ -30,7 +30,7 @@ body {
   background-color: #faf2e6;
   font-size: 18px;
   font-family: 'Lato', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial,
-  sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol';
+    sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol';
 }
 
 /* Imitate bootstrap container */
@@ -266,7 +266,6 @@ input#submitForm:hover {
   height: 38px;
 }
 
-
 #payment_credit_card_number,
 #payment_credit_card_secure_id {
   background-color: #fffdfb;
@@ -345,4 +344,8 @@ input#submitForm,
 #securityBox,
 #creditCardForm .small.info {
   font-size: 14px;
+}
+
+div.alert > div.shariff {
+  padding-bottom: 50px;
 }


### PR DESCRIPTION
The fact that we had increased the font size on the iframe pushed
everything down. Therefore to compensate it we added padding to the
social 'share' buttons.

How it looked before:
![screen_shot_2018-01-19_at_10 56 29](https://user-images.githubusercontent.com/825836/35268052-61df4440-0028-11e8-816b-7bb1bbc67316.png)