### PR TITLE
Remove credit card field styles from fundraisingbox css

### DIFF
--- a/Fundraisingbox_custom_css.css
+++ b/Fundraisingbox_custom_css.css
@@ -117,13 +117,6 @@ select {
   background-color: #fffdfb;
 }
 
-#creditCardForm > div:nth-of-type(2) > div.label,
-#creditCardForm > div:nth-of-type(4) > div.label {
-  -webkit-transform: translateY(-6px);
-  -ms-transform: translateY(-6px);
-  transform: translateY(-6px);
-}
-
 input#submitForm {
   margin-bottom: 30px;
   cursor: pointer;
@@ -154,9 +147,7 @@ input#submitForm:hover {
 }
 
 .paymentDetails input[type='text'],
-.paymentDetails select,
-#payment_credit_card_number,
-#payment_credit_card_secure_id {
+.paymentDetails select {
   padding: 0.375rem 0.75rem;
   line-height: 1.5;
   color: #495057;
@@ -167,9 +158,7 @@ input#submitForm:hover {
 }
 
 .paymentDetails div.field input[type='text']:focus,
-.paymentDetails select:focus,
-#payment_credit_card_number.focus,
-#payment_credit_card_secure_id.focus {
+.paymentDetails select:focus {
   border-color: #80bdff;
   -webkit-box-shadow: 0 0 0 0.2rem rgba(0, 123, 255, 0.25);
   box-shadow: 0 0 0 0.2rem rgba(0, 123, 255, 0.25);
@@ -230,11 +219,6 @@ input#submitForm:hover {
   padding-left: 70px;
 }
 
-#paymentmethods input#credit_card + label {
-  background-position: 5px -200px;
-  padding-left: 115px;
-}
-
 #paymentmethods input#paypal + label {
   background-position: 5px -80px;
   padding-left: 105px;
@@ -284,8 +268,7 @@ input#submitForm:hover {
 div#bankConfirmation,
 div#additionalSettings,
 div#securityBox,
-input#submitForm,
-#creditCardForm .small.info {
+input#submitForm {
   margin-left: calc(25% + 8px);
 }
 
@@ -293,8 +276,7 @@ input#submitForm,
   div#bankConfirmation,
   div#additionalSettings,
   div#securityBox,
-  input#submitForm,
-  #creditCardForm .small.info {
+  input#submitForm {
     margin-left: 0;
   }
 }
@@ -341,8 +323,7 @@ input#submitForm,
 
 #bankConfirmation,
 #additionalSettings,
-#securityBox,
-#creditCardForm .small.info {
+#securityBox {
   font-size: 14px;
 }
 


### PR DESCRIPTION
We removed the credit card payment option from the form in the Fundraisingbox interface. As Masifunde says the administration costs of allowing credit card payments is too high, they're most likely not gonna enable it (at least not in the foreseeable future).

As a result I removed the credit card field styles from the Fundraisingbox css in order to keep the css file more clean, less cluttered, and more legible.