### PR TITLE
Fix button link client side navigation

### DIFF
--- a/components/Button.js
+++ b/components/Button.js
@@ -14,10 +14,10 @@ const Button = ({
   center,
   children,
   className,
-  href,
+  ...rest
 }) => (
   <ButtonContainer center={center}>
-    <a href={href} className={`btn ${className}`}>
+    <a {...rest} className={`btn ${className}`}>
       {children}
     </a>
   </ButtonContainer>


### PR DESCRIPTION
Pass Button rest props to anchor tag for client navigation.
We didn't pass the onClick prop through the custom React element through to the anchor tag. That disabled the anchor from doing client side navigation, and rather resulted in a full page navigation on every button link.