### PR TITLE
Make hero headline a <p>

### DIFF
--- a/components/Hero/Headline.js
+++ b/components/Hero/Headline.js
@@ -9,7 +9,7 @@ import { smallSpacing, mediumSpacing, largeSpacing } from '../../styling/sizes'
 export const HEADLINE_MIDDLE = 'middle'
 export const HEADLINE_BOTTOM = 'bottom'
 
-const Headline = styled.span`
+const Headline = styled.p`
   word-wrap: break-word;
   hyphens: auto;
   width: 100%;


### PR DESCRIPTION
`<span>` is the `<div>` of inline elements - meaningless. It's not really a heading, either, so `<p>` seems to make the most sense.