### PR TITLE
Normalize alt tags

### DIFF
--- a/components/Carousel.js
+++ b/components/Carousel.js
@@ -191,8 +191,8 @@ class MasifundeCarousel extends Component {
         <StyledCarousel {...settings}>
           {items.map(item => (
             <SlideRow className="row" key={`${item.heading} ${item.image.url}`}>
-              <Image className="col-md-4" src={item.image.url} alt={item.image.title} />
-              <MobileImage src={item.image.url} alt={item.image.title} />
+              <Image className="col-md-4" src={item.image.url} alt="" />
+              <MobileImage src={item.image.url} alt="" />
               <CarouselTextContainer className="col-md-8">
                 <CarouselTextTitle>{item.heading}</CarouselTextTitle>
                 <Markdown source={item.text} />

--- a/components/DonationForm/FundraisingboxLink.js
+++ b/components/DonationForm/FundraisingboxLink.js
@@ -6,7 +6,7 @@ const FundraisingboxLink = () => (
       border="0"
       style={{ border: '0 !important' }}
       src="https://secure.fundraisingbox.com/images/FundraisingBox-Logo-Widget.png"
-      alt="FundraisingBox Logo"
+      alt="Powered by FundraisingBox"
     />
   </a>
 )

--- a/components/Header/index.js
+++ b/components/Header/index.js
@@ -55,7 +55,7 @@ class Header extends Component {
                 height={height}
                 className="d-flex align-items-center"
               >
-                <Logo src="/static/images/logo.svg" alt="Masifunde Logo" />
+                <Logo src="/static/images/logo.svg" alt="" />
               </StyledNavbarBrand>
             </Link>
             <NavbarToggler onClick={this.toggle} />

--- a/components/Header/index.js
+++ b/components/Header/index.js
@@ -55,7 +55,7 @@ class Header extends Component {
                 height={height}
                 className="d-flex align-items-center"
               >
-                <Logo src="/static/images/logo.svg" alt="" />
+                <Logo src="/static/images/logo.svg" alt="Masifunde home" />
               </StyledNavbarBrand>
             </Link>
             <NavbarToggler onClick={this.toggle} />

--- a/components/PartnersList/Partner.js
+++ b/components/PartnersList/Partner.js
@@ -35,7 +35,7 @@ const Partner = ({
     <PartnerContainer>
       <Link href={link}>
         <ImageContainer>
-          <Image src={image.url} alt={image.title} />
+          <Image src={image.url} alt="" />
         </ImageContainer>
         <div>{name}</div>
       </Link>

--- a/components/Stat.js
+++ b/components/Stat.js
@@ -51,7 +51,7 @@ const Stat = ({
           <CenteredSpan>{textAbove}</CenteredSpan>
         </FixedHeight>
       )}
-      {hasImage && <Image src={icon.url} alt={icon.title} />}
+      {hasImage && <Image src={icon.url} alt="" />}
       <Number highlight={!hasImage}>{number}</Number>
       <CenteredSpan>
         {description}

--- a/components/TeamMember.js
+++ b/components/TeamMember.js
@@ -37,7 +37,7 @@ const TeamMember = ({
       <Image
         className="img-fluid"
         src={imageUrl}
-        alt={`${title} - ${subtitle}`}
+        alt=""
       />
       <Title>{title}</Title>
       <div>{subtitle}</div>

--- a/pages/what-we-do/index.js
+++ b/pages/what-we-do/index.js
@@ -95,7 +95,7 @@ const ProjectList = ({ projects }) => (
         className="col-sm-6"
         key={`${project.image.url} ${project.name}`}
       >
-        <ProjectImage src={project.image.url} alt={project.image.title} />
+        <ProjectImage src={project.image.url} alt="" />
         <ProjectText>{project.name}</ProjectText>
       </Project>
       ))}


### PR DESCRIPTION
In some cases, alt tags shouldn't be populated for accessibility. 

I left some alt non-empty tags in the actual content where the images are actually taking some space on the page. Those are mostly in `page` folder like map images etc.

The header image logo should be added via CSS with `background-image` instead of using image.