### PR TITLE
Add another intro section in Donation page

### DIFF
--- a/pages/how-to-support/donate.js
+++ b/pages/how-to-support/donate.js
@@ -16,9 +16,20 @@ import { SA_PROJECT_ID } from '../../components/DonationForm/constants/formValue
 import { PROJECT_ID } from '../../components/DonationForm/constants/fieldNames'
 import withQueryParams from '../../components/withQueryParams'
 import Markdown from '../../components/Markdown'
+import { extraSmallSpacing } from '../../styling/sizes'
 
 const MainHeading = styled.h1`
   width: 100%;
+`
+
+const MarkdownWithCustomList = styled(Markdown)`
+  ul {
+    list-style-image: url('/static/images/bullet-check.svg');
+  }
+
+  li {
+    margin-top: ${extraSmallSpacing};
+  }
 `
 
 const Donate = ({
@@ -51,7 +62,7 @@ const Donate = ({
     </PageSection>
 
     <FormContainer>
-      <Markdown source={intro2Markdown} />
+      <MarkdownWithCustomList source={intro2Markdown} />
     </FormContainer>
 
     <DonationForm

--- a/pages/how-to-support/donate.js
+++ b/pages/how-to-support/donate.js
@@ -25,10 +25,10 @@ const MainHeading = styled.h1`
 const MarkdownWithCustomList = styled(Markdown)`
   ul {
     list-style-image: url('/static/images/bullet-check.svg');
-  }
 
-  li {
-    margin-top: ${extraSmallSpacing};
+    li {
+      margin-top: ${extraSmallSpacing};
+    }
   }
 `
 

--- a/pages/how-to-support/donate.js
+++ b/pages/how-to-support/donate.js
@@ -10,10 +10,12 @@ import { fetchDonatePage } from '../../api/howToSupport'
 import withLayout from '../../components/withLayout'
 import DonationForm from '../../components/DonationForm'
 import PageSection from '../../components/PageSection'
+import FormContainer from '../../components/DonationForm/FormContainer'
 import CenteredText from '../../components/CenteredText'
 import { SA_PROJECT_ID } from '../../components/DonationForm/constants/formValues'
 import { PROJECT_ID } from '../../components/DonationForm/constants/fieldNames'
 import withQueryParams from '../../components/withQueryParams'
+import Markdown from '../../components/Markdown'
 
 const MainHeading = styled.h1`
   width: 100%;
@@ -25,6 +27,7 @@ const Donate = ({
   bannerTitle,
   introHeading,
   introMarkdown,
+  intro2Markdown,
   metaDescription,
   metaTitle,
   section1MarkdownDe,
@@ -46,6 +49,10 @@ const Donate = ({
       <MainHeading>{introHeading}</MainHeading>
       <CenteredText source={introMarkdown} />
     </PageSection>
+
+    <FormContainer>
+      <Markdown source={intro2Markdown} />
+    </FormContainer>
 
     <DonationForm
       amounts={section3ReferenceList}
@@ -80,6 +87,7 @@ Donate.propTypes = {
   metaDescription: PropTypes.string,
   introHeading: PropTypes.string.isRequired,
   introMarkdown: PropTypes.string.isRequired,
+  intro2Markdown: PropTypes.string.isRequired,
   section1title: PropTypes.string.isRequired,
   section1MarkdownDe: PropTypes.string.isRequired,
   section1MarkdownSa: PropTypes.string.isRequired,

--- a/static/images/bullet-check.svg
+++ b/static/images/bullet-check.svg
@@ -1,12 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- Generator: Adobe Illustrator 22.0.1, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
-<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"
-	 viewBox="0 4 24 16" xml:space="preserve" width="24px" height="16px">
+<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+	 viewBox="0 4 24 16" style="enable-background:new 0 0 24 24;" xml:space="preserve" width="24px" height="16px">
 <style type="text/css">
 	.st0{fill:#FF9933;}
 </style>
-<g>
-	<path class="st0" d="M9,19.5c-0.4,0-0.7-0.1-1-0.4l-6.4-6.4c-0.5-0.5-0.5-1.4,0-1.9c0.5-0.5,1.4-0.5,1.9,0L9,16.2L20.4,4.9
-		c0.5-0.5,1.4-0.5,1.9,0c0.5,0.5,0.5,1.4,0,1.9L10,19.1C9.7,19.4,9.4,19.5,9,19.5z"/>
-</g>
+<path class="st0" d="M23,4.2c-0.9-0.9-2.4-0.9-3.3,0L9,14.8l-4.8-4.7c-0.9-0.9-2.4-0.9-3.3,0C0,11,0,12.5,0.9,13.4l6.4,6.4
+	c0.5,0.5,1,0.7,1.7,0.7s1.2-0.2,1.7-0.7L23,7.5C23.9,6.6,23.9,5.1,23,4.2z"/>
 </svg>

--- a/static/images/bullet-check.svg
+++ b/static/images/bullet-check.svg
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- Generator: Adobe Illustrator 22.0.1, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
 <svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"
-	 viewBox="0 4 24 16" xml:space="preserve" width="24px">
+	 viewBox="0 4 24 16" xml:space="preserve" width="24px" height="16px">
 <style type="text/css">
 	.st0{fill:#FF9933;}
 </style>

--- a/static/images/bullet-check.svg
+++ b/static/images/bullet-check.svg
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Generator: Adobe Illustrator 22.0.1, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"
+	 viewBox="0 4 24 16" xml:space="preserve" width="24px">
+<style type="text/css">
+	.st0{fill:#FF9933;}
+</style>
+<g>
+	<path class="st0" d="M9,19.5c-0.4,0-0.7-0.1-1-0.4l-6.4-6.4c-0.5-0.5-0.5-1.4,0-1.9c0.5-0.5,1.4-0.5,1.9,0L9,16.2L20.4,4.9
+		c0.5-0.5,1.4-0.5,1.9,0c0.5,0.5,0.5,1.4,0,1.9L10,19.1C9.7,19.4,9.4,19.5,9,19.5z"/>
+</g>
+</svg>


### PR DESCRIPTION
Added centered intro block after the introduction.

![screen shot 2018-02-07 at 13 26 04](https://user-images.githubusercontent.com/825836/35916386-873d4e6a-0c0a-11e8-8524-34357e19faa2.png)

It would be best if @erikjalevik would look at this since I didn't have designs to do this.
