### PR TITLE
Display proper team member info

### DIFF
--- a/components/TextWithTeamMember.js
+++ b/components/TextWithTeamMember.js
@@ -6,7 +6,12 @@ import TeamMember from './TeamMember'
 import teamMemberShape from '../propTypes/teamMember'
 
 
-const TextWithTeamMember = ({ text, teamMember }) => (
+const TextWithTeamMember = ({
+  text,
+  teamMember,
+  title,
+  subtitle,
+}) => (
   <div className="row">
     <div className="col-md-9">
       <Markdown source={text} />
@@ -14,8 +19,8 @@ const TextWithTeamMember = ({ text, teamMember }) => (
     <TeamMember
       className="col-md-3"
       imageUrl={teamMember.image.url}
-      title={teamMember.name}
-      subtitle={teamMember.responsibilityArea}
+      title={title}
+      subtitle={subtitle}
       email={teamMember.email}
     />
   </div>
@@ -23,6 +28,8 @@ const TextWithTeamMember = ({ text, teamMember }) => (
 
 TextWithTeamMember.propTypes = {
   text: PropTypes.string.isRequired,
+  title: PropTypes.string.isRequired,
+  subtitle: PropTypes.string.isRequired,
   teamMember: PropTypes.shape(teamMemberShape).isRequired,
 }
 

--- a/pages/contact/index.js
+++ b/pages/contact/index.js
@@ -55,7 +55,7 @@ const Contact = ({
       <TeamMemberListTitle>{contactsHeading}</TeamMemberListTitle>
       <TeamMemberList
         members={contacts}
-        title={member => member.region}
+        title={member => member.responsibilityArea}
         subtitle={member => member.name}
         imageUrl={member => member.image.url}
         email={member => member.email}

--- a/pages/how-to-support/become-partner.js
+++ b/pages/how-to-support/become-partner.js
@@ -40,6 +40,8 @@ const BecomePartner = ({
       <TextWithTeamMember
         text={section1Markdown}
         teamMember={teamMember}
+        title={teamMember.name}
+        subtitle={teamMember.responsibilityArea}
       />
     </PageSection>
 

--- a/pages/how-to-support/become-volunteer.js
+++ b/pages/how-to-support/become-volunteer.js
@@ -48,6 +48,8 @@ const BecomeVolunteer = ({
       <TextWithTeamMember
         text={section1Markdown}
         teamMember={section1TeamMember}
+        title={section1TeamMember.name}
+        subtitle={section1TeamMember.responsibilityArea}
       />
     </PageSection>
 

--- a/pages/what-we-do/approach-de.js
+++ b/pages/what-we-do/approach-de.js
@@ -86,6 +86,8 @@ const ApproachDe = ({
       <TextWithTeamMember
         text={section1Markdown}
         teamMember={teamMember}
+        title={teamMember.name}
+        subtitle={teamMember.responsibilityArea}
       />
     </PageSection>
 


### PR DESCRIPTION
Even though I'm now passing `title` and `subtitle` explicitly I decided to still pass the entire team member, instead of also explicitly passing the `image` and `email`. (For now) they are always required/used anyway. But I'm not very adamant about that.