### PR TITLE
Log which features are being enabled on build.

### DIFF
--- a/utils/isFeatureEnabled.js
+++ b/utils/isFeatureEnabled.js
@@ -2,10 +2,13 @@ let enabledFeatures
 
 if (typeof process.env.ENABLED_FEATURES === 'string') {
   enabledFeatures = process.env.ENABLED_FEATURES.split(',')
+  console.log('Feature flags: Enabling features', enabledFeatures)
 } else if (process.env.NODE_ENV !== 'production') {
   enabledFeatures = ['*']
+  console.log('Feature flags: Enabling all features.')
 } else {
   enabledFeatures = []
+  console.log('Feature flags: Enabling no features.')
 }
 
 export default function isFeatureEnabled(name) {


### PR DESCRIPTION
This will make it clear which features are being enabled on build, making you not have to wonder. I see this as pretty useful information during the build/deploy, and it's only a single `console.log`, so it won't cause a mess.