### PR TITLE
Fix RegionalGroups line break

### DIFF
--- a/components/RegionalGroups.js
+++ b/components/RegionalGroups.js
@@ -19,6 +19,7 @@ const LocationsList = styled.ul`
 `
 
 const LocationListItem = styled.li`
+  display: inline-block;
   padding: 0.6rem ${extraSmallSpacing};
   padding-left: 0;
 `


### PR DESCRIPTION
Prohobit one city's contact details to start in one column and end in the other.
**Before:**
![image](https://user-images.githubusercontent.com/3830142/36030333-0d37df60-0da7-11e8-9db3-6406150540a7.png)
**After:**
![image](https://user-images.githubusercontent.com/3830142/36030336-12dbb680-0da7-11e8-898b-8d8d24cba2a4.png)
