### PR TITLE
Add missing entry to package-lock.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11029,6 +11029,12 @@
       "resolved": "https://registry.npmjs.org/validator/-/validator-9.4.0.tgz",
       "integrity": "sha512-ftkCYp/7HrGdybVCuwSje07POAd93ksZJpb5GVDBzm8SLKIm3QMJcZugb5dOJsONBoWhIXl0jtoGHTyou3DAgA=="
     },
+    "vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha1-IpnwLG3tMNSllhsLn3RSShj2NPw=",
+      "dev": true
+    },
     "verror": {
       "version": "1.10.0",
       "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",


### PR DESCRIPTION
This popped up when I ran `npm install` on pristine `master`.