### PR TITLE
Google Analytics anonymize IPs.

### DIFF
--- a/components/withAnalytics.js
+++ b/components/withAnalytics.js
@@ -3,8 +3,14 @@ import ReactGA from 'react-ga'
 
 import { GOOGLE_ANALYTICS_ID } from '../env'
 
+const gaOptions = {
+  anonymizeIp: true,
+}
+
 if (GOOGLE_ANALYTICS_ID) {
-  ReactGA.initialize(GOOGLE_ANALYTICS_ID)
+  ReactGA.initialize(GOOGLE_ANALYTICS_ID, {
+    gaOptions,
+  })
 }
 
 const withAnalytics = WrappedComponent =>


### PR DESCRIPTION
For tracking with Google Analytics we use react-ga. When initializing react-ga we can add a `gaOptions` object which sets the options we want to use for Google Analytics.
https://github.com/react-ga/react-ga#reactgainitializegatrackingid-options

The Google analytics options can be found here: https://developers.google.com/analytics/devguides/collection/analyticsjs/field-reference