### PR TITLE
Skip blog routes if release10 flag is off

### DIFF
--- a/featureFlags.js
+++ b/featureFlags.js
@@ -1,6 +1,6 @@
-/* eslint-disable import/prefer-default-export */
-import isFeatureEnabled from './utils/isFeatureEnabled'
+// NOTE: Using CommonJS imports / exports for use in next.config.js
+const isFeatureEnabled = require('./utils/isFeatureEnabled')
 
-export default {
+module.exports = {
   release10: isFeatureEnabled('release10'),
 }

--- a/next.config.js
+++ b/next.config.js
@@ -5,6 +5,7 @@ const fs = require('fs')
 const webpack = require('webpack')
 
 const env = require('./env')
+const featureFlags = require('./featureFlags')
 const locales = require('./i18n/locales')
 const Routes = require('./routes')
 const createSitemap = require('./utils/sitemap')
@@ -104,7 +105,7 @@ module.exports = {
 
   async exportPathMap() {
     const staticRoutesMap = staticRoutesPathMap()
-    const blogPostsMap = await blogPostsPathMap()
+    const blogPostsMap = featureFlags.release10 ? await blogPostsPathMap() : {}
     const pathMap = Object.assign({}, staticRoutesMap, blogPostsMap)
 
     // Save routes as sitemap

--- a/routes.js
+++ b/routes.js
@@ -1,6 +1,7 @@
 // NOTE: Using CommonJS imports / exports for use in next.config.js
 
 const nextRoutes = require('next-routes')()
+const featureFlags = require('./featureFlags')
 const locales = require('./i18n/locales')
 
 /**
@@ -67,8 +68,11 @@ addRoute('wie-sie-helfen/spenden', Donate)
 addRoute('kontakt', Contact)
 addRoute('impressum', Impressum)
 addRoute('datenschutz', Datenschutz)
-addRoute('blog', Blog)
-addRoute('blog/:slug', BlogPost)
+
+if (featureFlags.release10) {
+  addRoute('blog', Blog)
+  addRoute('blog/:slug', BlogPost)
+}
 
 // Share route names
 nextRoutes.RouteNames = {

--- a/utils/isFeatureEnabled.js
+++ b/utils/isFeatureEnabled.js
@@ -1,3 +1,5 @@
+// NOTE: Using CommonJS imports / exports for use in next.config.js
+
 let enabledFeatures
 
 if (typeof process.env.ENABLED_FEATURES === 'string') {
@@ -11,6 +13,6 @@ if (typeof process.env.ENABLED_FEATURES === 'string') {
   console.log('Feature flags: Enabling no features.')
 }
 
-export default function isFeatureEnabled(name) {
+module.exports = function isFeatureEnabled(name) {
   return enabledFeatures.includes(name) || enabledFeatures.includes('*')
 }


### PR DESCRIPTION
The blog wasn't linked to from anywhere, but the routes still existed. Now they don't.