### PR TITLE
Add script for importing the exported blog posts

### DIFF
--- a/blog_migration/importBlogPosts.js
+++ b/blog_migration/importBlogPosts.js
@@ -1,0 +1,114 @@
+/* eslint-disable no-console, import/no-extraneous-dependencies */
+const fs = require('fs')
+const contentfulManagement = require('contentful-management')
+const slug = require('slug')
+
+const env = require('../env')
+
+function loadPostsFromExport() {
+  const filename = `${__dirname}/blog_export_with_contentful_image_urls.json`
+  const json = fs.readFileSync(filename, 'utf8')
+  return JSON.parse(json)
+}
+
+function preparePostContent(postBodyText) {
+  return postBodyText
+    // Expand single-endline paragraph breaks to blank lines
+    .replace(/[\r\n]+/g, '\n\n')
+    // Convert <b> and <i> to Markdown
+    .replace(/<\/?i>/g, '_')
+    .replace(/<\/?b>/g, '__')
+    // Replace <img> tags with Mardown ![...](...) syntax and put them
+    // into their own paragraph. If something is before the <img> (e.g.
+    // an opening <b> tag, as seen in some posts), move to the start
+    // of the next paragraph.
+    .replace(/^(.*?)<img src="(\S+)".*?\/>\s*/gm, '![]($2)\n\n$1')
+    // The post body contains some weird non-standard <link> tags that
+    // look like this:
+    //
+    // <link https://example.com/path/to/somewhere>A document</link>
+    // <link alice@example.com - mail>alice[at]example.com</link>
+    // <link //domain/path/to/file.pdf>A document</link>
+    // <link alice@example.com - mail>alice[at]example.com</link>
+    //
+    // The following line converts these to the [...](...) Markdown syntax.
+    //
+    // Many posts also contain links to internal pages of the old site,
+    // referring to them by their internal page ID like this:
+    //
+    // <link 57 - internal link>...</link>
+    //
+    // Most of these we don't have any equivalent for, so we map them
+    // to the (non-existent) /blog/internal/:id for now...
+    .replace(/<link (\d+) .*?>(.*?)<\/link>/g, '[$2](/blog/internal/$1)')
+    .replace(/<link (\S+) - mail.*?>(.*?)<\/link>/g, '[$2](mailto:$1)')
+    .replace(/<link (\S+?)>(.*?)<\/link>/g, '[$2]($1)')
+    .replace(/<link (\S+).*?>(.*?)<\/link>/g, '[$2]($1)')
+    // Some posts' content starts with blank lines that we don't want to keep.
+    .trim()
+}
+
+function createAssetLink(assetUrl) {
+  // The asset URLs look like this:
+  // //images.contentful.com/6jocdllnp50q/4C5fiodkVWCCaka8cUCqUy/...
+  // The second path segment is the asset ID.
+  const assetId = assetUrl.split('/')[4]
+
+  return {
+    sys: {
+      type: 'Link',
+      linkType: 'Asset',
+      id: assetId,
+    },
+  }
+}
+
+async function importBlogPost(post, space) {
+  const fields = {
+    title: { de: post.title },
+    slug: { de: slug(post.title, { lower: true }) },
+    metaDescription: { de: post.teaser },
+    teaserImage: { en: createAssetLink(post.teaserImage) },
+    date: { en: new Date(post.datetime * 1000).toISOString() },
+    content: { de: preparePostContent(post.bodytext) },
+  }
+
+  const id = `imported-blog-post-${post.uid}`
+  let entry = await space.getEntry(id).catch(() => null)
+
+  if (entry) {
+    Object.assign(entry.fields, fields)
+    entry = await entry.update()
+  } else {
+    entry = await space.createEntryWithId('blogPost', id, { fields })
+  }
+
+  await entry.publish()
+}
+
+function delay(ms) {
+  return new Promise(resolve => setTimeout(resolve, ms))
+}
+
+async function main() {
+  const client = contentfulManagement.createClient({
+    accessToken: process.env.CONTENTFUL_MANAGEMENT_ACCESS_TOKEN,
+  })
+  const space = await client.getSpace(env.CONTENTFUL_SPACE_ID)
+  const posts = loadPostsFromExport()
+
+  // To not hit the Contentful API rate limit, we need to import the
+  // posts one by one with some delay between requests.
+
+  /* eslint-disable no-restricted-syntax, no-await-in-loop */
+  for (const post of posts) {
+    console.log(`Importing post ${post.uid}…`)
+    await importBlogPost(post, space)
+    await delay(50)
+  }
+  /* eslint-enable no-restricted-syntax, no-await-in-loop */
+
+  console.log('Done!')
+}
+
+main().catch(err => console.error(err.stack))

--- a/package-lock.json
+++ b/package-lock.json
@@ -2378,6 +2378,17 @@
         "lodash": "4.17.4"
       }
     },
+    "contentful-management": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/contentful-management/-/contentful-management-4.2.0.tgz",
+      "integrity": "sha512-nhWQnPErUPwsYOnk9+o9Z4qMHjRwho4/yzOXT3qToAEe9WpEb0AcrtLVzvQNolzdP8n1O+ayrPIhtCPbqp5BVg==",
+      "dev": true,
+      "requires": {
+        "@contentful/axios": "0.18.0",
+        "contentful-sdk-core": "5.0.1",
+        "lodash": "4.17.4"
+      }
+    },
     "contentful-sdk-core": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/contentful-sdk-core/-/contentful-sdk-core-5.0.1.tgz",
@@ -8645,6 +8656,15 @@
       "resolved": "https://registry.npmjs.org/slide/-/slide-1.1.6.tgz",
       "integrity": "sha1-VusCfWW00tzmyy4tMsTUr8nh1wc="
     },
+    "slug": {
+      "version": "0.9.1",
+      "resolved": "https://registry.npmjs.org/slug/-/slug-0.9.1.tgz",
+      "integrity": "sha1-rwj2CKfBFRa2F3iqgA3OhMUYz9o=",
+      "dev": true,
+      "requires": {
+        "unicode": "10.0.0"
+      }
+    },
     "snapdragon": {
       "version": "0.8.1",
       "resolved": "https://registry.npmjs.org/snapdragon/-/snapdragon-0.8.1.tgz",
@@ -9789,6 +9809,12 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/unfetch/-/unfetch-3.0.0.tgz",
       "integrity": "sha1-jR4FE6Ts0OX/LUGmund3Gq6LZII="
+    },
+    "unicode": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/unicode/-/unicode-10.0.0.tgz",
+      "integrity": "sha1-5dUcHbk7bHGguHngsMSvfm/faI4=",
+      "dev": true
     },
     "union-value": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
     "babel-plugin-polished": "^1.1.0",
     "babel-plugin-styled-components": "^1.5.0",
     "babel-plugin-transform-inline-environment-variables": "^0.2.0",
+    "contentful-management": "^4.2.0",
     "cpx": "^1.5.0",
     "eslint": "^4.16.0",
     "eslint-config-airbnb": "^16.1.0",
@@ -76,6 +77,7 @@
     "lint-staged": "^6.0.1",
     "nodemon": "^1.14.11",
     "rimraf": "^2.6.2",
-    "serve": "^6.4.9"
+    "serve": "^6.4.9",
+    "slug": "^0.9.1"
   }
 }


### PR DESCRIPTION
This is not perfect by any means, but good enough that I already ran it on our Contentful space. The main remaining problem is that many posts have internal links that look like this:

```
<link 57 - internal link "Open">Mehr Informationen...</link>
```

where 57 is the internal ID of the target on the old website... currently, this script just links all of those to a non-existing URL (`/blog/internal/$ID`).

The script is written to be idempotent (it replaces the already-imported posts instead of creating a new set every run), so we can always improve it and run the script again.