### PR TITLE
Skip posts without slug during route generation

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -85,8 +85,15 @@ async function blogPostsPathMap() {
   posts.forEach((post) => {
     locales.forEach((locale) => {
       const slug = post.fields.slug[locale]
-      const path = putLocale(`/:locale?/blog/${slug}`, locale)
 
+      // Without a slug, we cannot generate a path for the blog post.
+      if (!slug) {
+        // eslint-disable-next-line no-console
+        console.warn(`Post ${post.sys.id} has no slug for locale [${locale}], skipping`)
+        return
+      }
+
+      const path = putLocale(`/:locale?/blog/${slug}`, locale)
       pathMap[path] = {
         page: Routes.RouteNames.BlogPost,
         query: {


### PR DESCRIPTION
It's possible that blog posts only have a German slug, but not an English one. The static export map generation code needs to be robust in that case.