### PR TITLE
Rename ENABLED_FEATURES=* to ENABLED_FEATURES=all

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,11 +74,13 @@ called `ENABLED_FEATURES`, like this:
 ENABLED_FEATURES=feature1,feature2 npm run dev
 
 # Enable all features (the default during development)
-ENABLED_FEATURES=* npm run dev
+ENABLED_FEATURES=all npm run dev
 
 # Disable all features (the default in production)
 ENABLED_FEATURES= npm run dev
 ```
+
+The special `all` value always enables all feature flags.
 
 Remember that feature flags are always temporary. Once a feature behind a
 flag goes to production, simply remove the flag altogether.

--- a/netlify.toml
+++ b/netlify.toml
@@ -9,4 +9,4 @@
 # Deploy Preview context: All Deploy Previews
 # will inherit these settings.
 [context.deploy-preview.environment]
-  ENABLED_FEATURES = "*"
+  ENABLED_FEATURES = "all"

--- a/next.config.js
+++ b/next.config.js
@@ -1,8 +1,6 @@
 /* eslint-disable no-param-reassign */
 const contentful = require('contentful')
 const fs = require('fs')
-// eslint-disable-next-line import/no-extraneous-dependencies
-const webpack = require('webpack')
 
 const env = require('./env')
 const featureFlags = require('./featureFlags')
@@ -119,12 +117,5 @@ module.exports = {
     fs.writeFileSync('public/sitemap.xml', createSitemap(pathMap))
 
     return pathMap
-  },
-
-  webpack(config) {
-    config.plugins.push(new webpack.DefinePlugin({
-      ENABLED_FEATURES: null,
-    }))
-    return config
   },
 }

--- a/utils/isFeatureEnabled.js
+++ b/utils/isFeatureEnabled.js
@@ -6,7 +6,7 @@ if (typeof process.env.ENABLED_FEATURES === 'string') {
   enabledFeatures = process.env.ENABLED_FEATURES.split(',')
   console.log('Feature flags: Enabling features', enabledFeatures)
 } else if (process.env.NODE_ENV !== 'production') {
-  enabledFeatures = ['*']
+  enabledFeatures = ['all']
   console.log('Feature flags: Enabling all features.')
 } else {
   enabledFeatures = []
@@ -14,5 +14,5 @@ if (typeof process.env.ENABLED_FEATURES === 'string') {
 }
 
 module.exports = function isFeatureEnabled(name) {
-  return enabledFeatures.includes(name) || enabledFeatures.includes('*')
+  return enabledFeatures.includes(name) || enabledFeatures.includes('all')
 }


### PR DESCRIPTION
The former name confused Netlify, which interpreted `*` as a shell glob and set `ENABLED_FEATURES` to the list of all files in the project root directory...