### PR TITLE
Change TextWithTeamMember component to new design

### DIFF
--- a/components/TextWithTeamMember.js
+++ b/components/TextWithTeamMember.js
@@ -5,32 +5,42 @@ import Markdown from './Markdown'
 import TeamMember from './TeamMember'
 import teamMemberShape from '../propTypes/teamMember'
 
-
 const TextWithTeamMember = ({
+  header,
   text,
   teamMember,
-  title,
-  subtitle,
+  teamMemberTitle,
+  teamMemberSubtitle,
 }) => (
   <div className="row">
-    <div className="col-md-9">
-      <Markdown source={text} />
+    <div className="col-lg-8 offset-lg-2">
+      <div className="row">
+        <div className="col-md-9">
+          { header && <h3>{header}</h3> }
+          <Markdown source={text} />
+        </div>
+        <TeamMember
+          className="col-md-3"
+          imageUrl={teamMember.image.url}
+          title={teamMemberTitle}
+          subtitle={teamMemberSubtitle}
+          email={teamMember.email}
+        />
+      </div>
     </div>
-    <TeamMember
-      className="col-md-3"
-      imageUrl={teamMember.image.url}
-      title={title}
-      subtitle={subtitle}
-      email={teamMember.email}
-    />
   </div>
 )
 
 TextWithTeamMember.propTypes = {
+  header: PropTypes.string,
   text: PropTypes.string.isRequired,
-  title: PropTypes.string.isRequired,
-  subtitle: PropTypes.string.isRequired,
+  teamMemberTitle: PropTypes.string.isRequired,
+  teamMemberSubtitle: PropTypes.string.isRequired,
   teamMember: PropTypes.shape(teamMemberShape).isRequired,
+}
+
+TextWithTeamMember.defaultProps = {
+  header: undefined,
 }
 
 export default TextWithTeamMember

--- a/pages/how-to-support/become-partner.js
+++ b/pages/how-to-support/become-partner.js
@@ -36,12 +36,12 @@ const BecomePartner = ({
     </PageSection>
 
     <PageSection>
-      <h2>{section1Title}</h2>
       <TextWithTeamMember
+        header={section1Title}
         text={section1Markdown}
         teamMember={teamMember}
-        title={teamMember.name}
-        subtitle={teamMember.responsibilityArea}
+        teamMemberTitle={teamMember.name}
+        teamMemberSubtitle={teamMember.responsibilityArea}
       />
     </PageSection>
 

--- a/pages/how-to-support/become-volunteer.js
+++ b/pages/how-to-support/become-volunteer.js
@@ -24,6 +24,8 @@ const BecomeVolunteer = ({
   metaTitle,
   metaDescription,
   introTitle,
+  introMarkdown,
+  section1Title,
   section1Markdown,
   section1TeamMember,
   section2Title,
@@ -48,11 +50,16 @@ const BecomeVolunteer = ({
 
     <PageSection>
       <h1>{introTitle}</h1>
+      <CenteredText source={introMarkdown} />
+    </PageSection>
+
+    <PageSection>
       <TextWithTeamMember
+        header={section1Title}
         text={section1Markdown}
         teamMember={section1TeamMember}
-        title={section1TeamMember.name}
-        subtitle={section1TeamMember.responsibilityArea}
+        teamMemberTitle={section1TeamMember.name}
+        teamMemberSubtitle={section1TeamMember.responsibilityArea}
       />
     </PageSection>
 
@@ -95,6 +102,8 @@ BecomeVolunteer.propTypes = {
   metaTitle: PropTypes.string.isRequired,
   metaDescription: PropTypes.string,
   introTitle: PropTypes.string.isRequired,
+  introMarkdown: PropTypes.string.isRequired,
+  section1Title: PropTypes.string.isRequired,
   section1Markdown: PropTypes.string.isRequired,
   section1TeamMember: PropTypes.shape().isRequired,
   section2Title: PropTypes.string.isRequired,

--- a/pages/what-we-do/approach-de.js
+++ b/pages/what-we-do/approach-de.js
@@ -82,12 +82,12 @@ const ApproachDe = ({
     </PageSection>
 
     <PageSection>
-      <h2>{section1Title}</h2>
       <TextWithTeamMember
+        header={section1Title}
         text={section1Markdown}
         teamMember={teamMember}
-        title={teamMember.name}
-        subtitle={teamMember.responsibilityArea}
+        teamMemberTitle={teamMember.name}
+        teamMemberSubtitle={teamMember.responsibilityArea}
       />
     </PageSection>
 


### PR DESCRIPTION
Change the layout of the TextWithTeamMember. Now it is smaller compared to the whole container and has a header. I also passed down the header in a few of the pages that it was used.

![screen shot 2018-02-15 at 09 19 11](https://user-images.githubusercontent.com/825836/36246746-7ee9d594-1231-11e8-8ef7-3a1ba11ac553.png)
