### PR TITLE
Filter out unresolvable links to contacts

### DIFF
--- a/api/contact.js
+++ b/api/contact.js
@@ -2,17 +2,20 @@
 import { fetchSingleEntry } from './contentfulService'
 import { unwrapImage, unwrapRegion } from './common'
 
+const unwrapContact = contact => ({
+  ...contact.fields,
+  region: unwrapRegion(contact.fields.region),
+  image: unwrapImage(contact.fields.profileImage),
+})
+
+const unwrapContacts = contacts =>
+  contacts.filter(c => !!c.fields).map(unwrapContact)
+
 export async function fetchContactPage(locale) {
   const content = await fetchSingleEntry('pageKontakt', locale)
-  const mapContact = contact => ({
-    ...contact.fields,
-    region: unwrapRegion(contact && contact.fields && contact.fields.region),
-    image: unwrapImage(contact && contact.fields && contact.fields.profileImage),
-  })
   return {
     ...content,
-    contacts: content && content.contacts && content.contacts.map(mapContact),
-    regionalContacts:
-      content && content.regionalContacts && content.regionalContacts.map(mapContact),
+    contacts: unwrapContacts(content.contacts),
+    regionalContacts: unwrapContacts(content.regionalContacts),
   }
 }


### PR DESCRIPTION
If a content editor removes a contact that was linked to from the contact page, an unresolvable link to that contact remains. We need to make sure to skip these links when fetching the contact page data.