### PR TITLE
Remove word-break rule from wordBreak util.

### DIFF
--- a/styling/utils.js
+++ b/styling/utils.js
@@ -9,12 +9,6 @@ export const wordBreak = css`
   overflow-wrap: break-word;
   word-wrap: break-word;
 
-  -ms-word-break: break-all;
-  /* This is the dangerous one in WebKit, as it breaks things wherever */
-  word-break: break-all;
-  /* Instead use this non-standard one: */
-  word-break: break-word;
-
   /* Adds a hyphen where the word breaks, if supported (No Blink) */
   hyphens: auto;
 `


### PR DESCRIPTION
The word-break rule (as opposed to the word-wrap and overflow-wrap rules) only has two values. break-all which doesn't try to preserve words, and break-word which is unofficial and not supported by all browsers.