### PR TITLE
Link from old website news paths to blog posts

### DIFF
--- a/public/_redirects
+++ b/public/_redirects
@@ -1,8 +1,5 @@
-# 404 page
-/en/*  /en/404  404
-/*     /404     404
-
 # Redirects
+/ueber-uns/news-archiv/news/:slug /blog/:slug
 /ueber-uns/* /wer-wir-sind
 /transparenz /was-wir-machen
 /projekte/*  /was-wir-machen
@@ -10,4 +7,7 @@
 /du-bei-masifunde/*  /wie-sie-helfen/aktiv-werden
 /unterwegs-in-de/* /was-wir-machen/ansatz-de/
 /jetzt-spenden/* /wie-sie-helfen/spenden
-/ueber-uns/news-archiv/news/:slug /blog/:slug
+
+# 404 page
+/en/*  /en/404  404
+/*     /404     404

--- a/public/_redirects
+++ b/public/_redirects
@@ -10,3 +10,4 @@
 /du-bei-masifunde/*  /wie-sie-helfen/aktiv-werden
 /unterwegs-in-de/* /was-wir-machen/ansatz-de/
 /jetzt-spenden/* /wie-sie-helfen/spenden
+/ueber-uns/news-archiv/news/:slug /blog/:slug


### PR DESCRIPTION
The slugs of the old posts seem to be pretty much the same as the new ones, so the redirect has a very high chance of leading to the correct blog post. If not, the user will probably land on a 404 page, which is no worse than before.