### PR TITLE
Fix stat list overflow on IE11

### DIFF
--- a/components/Stat.js
+++ b/components/Stat.js
@@ -3,8 +3,20 @@ import styled, { css } from 'styled-components'
 import PropTypes from 'prop-types'
 import { handwrittenText, rem } from '../styling/typography'
 import Source from './Source'
+import { smBreakpoint } from '../styling/breakpoints'
 
 const StatContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  
+  /* IE11 fix */
+  flex-shrink: 1;
+  flex-basis: auto;
+  @media(min-width: ${smBreakpoint}) {
+    flex-basis: 0;
+  }
+
   font-size: ${rem('18px')};
   font-weight: bold;
 `
@@ -45,7 +57,7 @@ const Stat = ({
 }) => {
   const hasImage = !!icon && !!icon.url
   return (
-    <StatContainer className={`${className} d-flex flex-column align-items-center`}>
+    <StatContainer className={`${className}`}>
       {!!textAbove && (
         <FixedHeight className="d-flex align-items-center">
           <CenteredSpan>{textAbove}</CenteredSpan>

--- a/pages/home.js
+++ b/pages/home.js
@@ -73,7 +73,7 @@ const Home = ({
     />
 
     <PageSection>
-      <StatList className="row">
+      <StatList>
         {
           stats.map((stat, index) => (
             <Stat


### PR DESCRIPTION
Looked like this in IE11 prior to fix:

![image](https://user-images.githubusercontent.com/3830142/36264357-cd6bdbc8-126c-11e8-872d-f97631965106.png)
