### PR TITLE
Fix pate werden amount reset bug.

### DIFF
--- a/components/DonationForm/RadioButton.js
+++ b/components/DonationForm/RadioButton.js
@@ -60,6 +60,7 @@ const RadioButton = ({
       id={id}
       name={name}
       value={value}
+      checked={isActive}
     />
     <Label
       {...inputProps}


### PR DESCRIPTION
On the Pate Werden page, when the user selects a donation interval, the donation amount should be reset. Prior to this PR it was bugged so that the donation amount wasn't reset in the model state (the radio button was still checked), but it was reset in the view (the radio button looked as though it was not checked)
When refactoring the radio button code and pulling it into its own component, the `checked` attribute was lost, so I just needed to add that back in.