### PR TITLE
Fixed TeamMember size bug.

### DIFF
--- a/components/TeamMember.js
+++ b/components/TeamMember.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types'
 import styled from 'styled-components'
 
 import RoundedImage from './RoundedImage'
+import { wordBreak } from '../styling/utils'
 
 const TeamContainer = styled.div`
   font-size: 16px;
@@ -10,9 +11,15 @@ const TeamContainer = styled.div`
   justify-content: center;
 `
 
-const Title = styled.div`
+const WordBreakDiv = styled.div`
+  ${wordBreak}
+`
+
+const Title = WordBreakDiv.extend`
   font-weight: bold;
 `
+
+const Subtitle = WordBreakDiv.extend``
 
 const Image = RoundedImage.extend`
   width: 100%;
@@ -42,7 +49,7 @@ const TeamMember = ({
         alt=""
       />
       <Title>{title}</Title>
-      <div>{subtitle}</div>
+      <Subtitle>{subtitle}</Subtitle>
       {email && (<Email href={`mailto:${email}`}>{email}</Email>)}
     </ContentContainer>
   </TeamContainer>

--- a/styling/utils.js
+++ b/styling/utils.js
@@ -8,6 +8,9 @@ export const wordBreak = css`
   /* These are technically the same, but use both for broader browser support */
   overflow-wrap: break-word;
   word-wrap: break-word;
+  
+  word-break: break-all;
+  word-break: break-word;
 
   /* Adds a hyphen where the word breaks, if supported (No Blink) */
   hyphens: auto;


### PR DESCRIPTION
Added word-break rules to wordBreak mixin.
We wanted to not use `word-break: break-all` at all, but
```
overflow-wrap: break-word;
word-wrap: break-word;
```
doesn't cut it in all circumstances. 
And `word-break: break-word` isn't supported by all browsers.

An example of how our `word-wrap` and `overflow-wrap` rules didn't cut it. This happened both on IE11 and Chrome (on Windows 10 at least).
![image](https://user-images.githubusercontent.com/3830142/36266912-fb215786-1272-11e8-9369-1ba1002c165c.png)
