### PR TITLE
Align patron and team member components

### DIFF
--- a/components/List.js
+++ b/components/List.js
@@ -1,6 +1,6 @@
 import styled, { css } from 'styled-components'
 import { smBreakpoint, mdBreakpoint, lgBreakpoint } from '../styling/breakpoints'
-import { extraSmallSpacing, smallSpacing } from '../styling/sizes'
+import { extraSmallSpacing, mediumSpacing } from '../styling/sizes'
 
 const centerIfSingleLine = (breakpoint, maxEntiresPerLine, numberOfEntries) => {
   if (numberOfEntries < maxEntiresPerLine) {
@@ -13,10 +13,10 @@ const centerIfSingleLine = (breakpoint, maxEntiresPerLine, numberOfEntries) => {
   return ''
 }
 
-const listItemBottomMargin = smallSpacing
+const listItemBottomMargin = mediumSpacing
 
-const smEntriesPerLine = 1
-const mdEntriesPerLine = 2
+const smEntriesPerLine = 2
+const mdEntriesPerLine = 3
 const lgEntriesPerLine = 4
 
 const List = styled.div`
@@ -24,7 +24,7 @@ const List = styled.div`
 
   display: flex;
   flex-wrap: wrap;
-  
+
   ${({ entries }) => centerIfSingleLine(smBreakpoint, smEntriesPerLine, entries.length)}
   ${({ entries }) => centerIfSingleLine(mdBreakpoint, mdEntriesPerLine, entries.length)}
   ${({ entries }) => centerIfSingleLine(lgBreakpoint, lgEntriesPerLine, entries.length)}
@@ -48,6 +48,11 @@ const List = styled.div`
       width: calc(100% / ${lgEntriesPerLine});
     }
   }
+`
+
+List.Item = styled.div`
+  display: flex;
+  justify-content: center;
 `
 
 export default List

--- a/components/PartnersList/Partner.js
+++ b/components/PartnersList/Partner.js
@@ -3,6 +3,10 @@ import PropTypes from 'prop-types'
 import styled from 'styled-components'
 import { teamMemberAndPartnerWidth } from '../../utils/constants'
 
+const PartnerContainer = styled.div`
+  width: ${teamMemberAndPartnerWidth};
+`
+
 const Link = styled.a`
   height: 100%;
 `
@@ -25,27 +29,24 @@ const ImageContainer = styled.div`
   margin-bottom: 5px;
 `
 
-const PartnerContainer = styled.div`
-  width: ${teamMemberAndPartnerWidth};
-`
-
 const PartnerName = styled.div`
   margin-top: 0.25rem;
 `
 
 const Partner = ({
-  image, name, link, className,
+  image,
+  name,
+  link,
+  className,
 }) => (
-  <div className={`d-flex justify-content-center ${className}`}>
-    <PartnerContainer>
-      <Link href={link}>
-        <ImageContainer>
-          <Image src={image.url} alt="" />
-        </ImageContainer>
-        <PartnerName>{name}</PartnerName>
-      </Link>
-    </PartnerContainer>
-  </div>
+  <PartnerContainer className={className}>
+    <Link href={link}>
+      <ImageContainer>
+        <Image src={image.url} alt="" />
+      </ImageContainer>
+      <PartnerName>{name}</PartnerName>
+    </Link>
+  </PartnerContainer>
 )
 
 export const propTypes = {

--- a/components/PartnersList/index.js
+++ b/components/PartnersList/index.js
@@ -12,12 +12,14 @@ const StyledList = List.extend`
 const PartnersList = ({ partnersList, className }) => (
   <StyledList entries={partnersList} className={`row ${className}`}>
     {partnersList.map(({ image, name, link }) => (
-      <Partner
-        link={link}
-        image={image}
-        name={name}
-        key={`${image.url} ${name}`}
-      />
+      <List.Item>
+        <Partner
+          link={link}
+          image={image}
+          name={name}
+          key={`${image.url} ${name}`}
+        />
+      </List.Item>
     ))}
   </StyledList>
 )

--- a/components/TeamMember.js
+++ b/components/TeamMember.js
@@ -3,29 +3,32 @@ import PropTypes from 'prop-types'
 import styled from 'styled-components'
 
 import RoundedImage from './RoundedImage'
+import { rem } from '../styling/typography'
 import { teamMemberAndPartnerWidth } from '../utils/constants'
 
-const TeamContainer = styled.div`
-  display: flex;
-  justify-content: center;
-`
-
-const Title = styled.div`
-  font-weight: bold;
-  margin-top: 0.25rem;
+const TeamMemberContainer = styled.div`
+  max-width: ${teamMemberAndPartnerWidth};
+  white-space: nowrap;
 `
 
 const Image = RoundedImage.extend`
   width: 100%;
+  margin-bottom: 0.7rem;
+`
+
+const Title = styled.div`
+  font-weight: bold;
+  margin: 0 0 0.3rem 0;
+`
+
+const Subtitle = styled.div`
+  color: ${({ theme }) => theme.pineCone};
+  font-size: ${rem('12px')};
 `
 
 const Email = styled.a`
   display: block;
-  word-break: break-all;
-`
-
-const ContentContainer = styled.div`
-  max-width: ${teamMemberAndPartnerWidth};
+  font-size: ${rem('12px')};
 `
 
 const TeamMember = ({
@@ -35,18 +38,16 @@ const TeamMember = ({
   email,
   className,
 }) => (
-  <TeamContainer className={className}>
-    <ContentContainer>
-      <Image
-        className="img-fluid"
-        src={imageUrl}
-        alt=""
-      />
-      <Title>{title}</Title>
-      <div>{subtitle}</div>
-      {email && (<Email href={`mailto:${email}`}>{email}</Email>)}
-    </ContentContainer>
-  </TeamContainer>
+  <TeamMemberContainer className={className}>
+    <Image
+      className="img-fluid"
+      src={imageUrl}
+      alt=""
+    />
+    <Title>{title}</Title>
+    <Subtitle>{subtitle}</Subtitle>
+    {email && (<Email href={`mailto:${email}`}>{email}</Email>)}
+  </TeamMemberContainer>
 )
 
 TeamMember.propTypes = {

--- a/components/TeamMemberList.js
+++ b/components/TeamMemberList.js
@@ -19,13 +19,14 @@ const TeamMemberList = ({
       const memberEmail = email && email(member)
 
       return (
-        <TeamMember
-          key={`${memberTitle} ${memberSubtitle}`}
-          title={memberTitle}
-          subtitle={memberSubtitle}
-          imageUrl={memberImageUrl}
-          email={memberEmail}
-        />
+        <List.Item key={`${memberTitle} ${memberSubtitle}`}>
+          <TeamMember
+            title={memberTitle}
+            subtitle={memberSubtitle}
+            imageUrl={memberImageUrl}
+            email={memberEmail}
+          />
+        </List.Item>
       )
     })}
   </List>

--- a/components/TestimonialList/Supporter.js
+++ b/components/TestimonialList/Supporter.js
@@ -19,7 +19,7 @@ const Name = styled.div`
   font-weight: bold;
   line-height: 1.22;
   color: ${({ theme }) => theme.orangeRed};
-  margin-bottom: 0.5rem;
+  margin-bottom: 0.3rem;
 `
 
 const Title = styled.div`

--- a/components/TextWithTeamMember.js
+++ b/components/TextWithTeamMember.js
@@ -19,13 +19,14 @@ const TextWithTeamMember = ({
           { header && <h3>{header}</h3> }
           <Markdown source={text} />
         </div>
-        <TeamMember
-          className="col-md-3"
-          imageUrl={teamMember.image.url}
-          title={teamMemberTitle}
-          subtitle={teamMemberSubtitle}
-          email={teamMember.email}
-        />
+        <div className="col-md-3">
+          <TeamMember
+            imageUrl={teamMember.image.url}
+            title={teamMemberTitle}
+            subtitle={teamMemberSubtitle}
+            email={teamMember.email}
+          />
+        </div>
       </div>
     </div>
   </div>

--- a/utils/constants.js
+++ b/utils/constants.js
@@ -1,4 +1,4 @@
 /* eslint-disable import/prefer-default-export */
 export const jpegQuality = 80
 export const fundraisingFormSpacing = '15px'
-export const teamMemberAndPartnerWidth = '240px'
+export const teamMemberAndPartnerWidth = '130px'


### PR DESCRIPTION
`TeamMember` now looks like the patron component, and also looks the same in `TeamMemberList` and `TextWithTeamMember` again (with a fixed image width).