### PR TITLE
Fix Divider propTypes warnings

### DIFF
--- a/components/Divider.js
+++ b/components/Divider.js
@@ -2,10 +2,10 @@ import PropTypes from 'prop-types'
 import styled, { css } from 'styled-components'
 import { smBreakpoint } from '../styling/breakpoints'
 
-const Divider = styled.hr.attrs({ role: 'presentation' })`  
+const Divider = styled.hr.attrs({ role: 'presentation' })`
   ${({ color, theme }) => ((color === 'grey' || color === 'gray')
     ? css`
-        border-color: #bbb; 
+        border-color: #bbb;
         border-width: 2px;
         opacity: 0.3;
       `
@@ -13,7 +13,7 @@ const Divider = styled.hr.attrs({ role: 'presentation' })`
         border-color: ${theme.orange};
       `
   )}
-  
+
   ${({ size }) => (
     size === 'large'
       ? css`
@@ -21,7 +21,7 @@ const Divider = styled.hr.attrs({ role: 'presentation' })`
         `
       : css`
           margin: 0 12%;
-    
+
           @media (min-width: ${smBreakpoint}) {
             margin: 0 22%;
           }
@@ -30,8 +30,8 @@ const Divider = styled.hr.attrs({ role: 'presentation' })`
 `
 
 Divider.propTypes = {
-  size: PropTypes.oneOf(['small, large']),
-  color: PropTypes.oneOf(['grey, gray, orange']),
+  size: PropTypes.oneOf(['small', 'large']),
+  color: PropTypes.oneOf(['grey', 'gray', 'orange']),
 }
 
 Divider.defaultProps = {


### PR DESCRIPTION
Instead of `oneOf(['small', 'large'])`, the code said `oneOf(['small, large'])`, making it so that only the value `'small, large'` was accepted as valid... 😅 