### PR TITLE
Fix cut-off checkmark bullet image

### DIFF
--- a/static/images/bullet-check.svg
+++ b/static/images/bullet-check.svg
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- Generator: Adobe Illustrator 22.0.1, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
 <svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
-	 viewBox="0 4 24 16" style="enable-background:new 0 0 24 24;" xml:space="preserve" width="24px" height="16px">
+	 viewBox="0 4 28 16" style="enable-background:new 0 0 24 24;" xml:space="preserve" width="24px" height="16px">
 <style type="text/css">
 	.st0{fill:#FF9933;}
 </style>


### PR DESCRIPTION
To fully control checkmark size, use a `::before` pseudo-element with a background image instead of `list-style-image`.