### PR TITLE
Fix breaking build

### DIFF
--- a/api/common.js
+++ b/api/common.js
@@ -51,7 +51,7 @@ export const unwrapStat = stat => ({
   icon: unwrapImage(stat && stat.fields && stat.fields.icon),
 })
 
-export const unwrapStats = stats => stats.map(unwrapStat)
+export const unwrapStats = (stats = []) => stats.map(unwrapStat)
 
 export const unwrapPageUrl = (pageUrl) => {
   if (!pageUrl) {


### PR DESCRIPTION
List elements should return empty array if they are undefined.