### PR TITLE
Tweak the "Aktiv werden" page again

### DIFF
--- a/api/howToSupport.js
+++ b/api/howToSupport.js
@@ -44,12 +44,25 @@ export async function fetchBecomeAVolunteerPage(locale) {
   const content = (await fetchMemoizedSingleEntry('pageAktivWerden', locale)) || {}
   return {
     ...content,
-    section1TeamMember: unwrapTeamMember(content && content.section1TeamMember),
-    volunteerOpenings: content && content.volunteerOpenings.map(unwrapVolunteerOpening),
     bannerButtonUrl: unwrapPageUrl(content.bannerButtonUrl),
-    section1ReferenceList: unwrapTestimonials(content.section1ReferenceList),
-    section5ReferenceList: unwrapTestimonials(content.section5ReferenceList),
-    section6TeamMember: unwrapTeamMember(content.section6TeamMember),
+
+    // Temporarily support old field ID's (section1Title etc.)
+    deTestimonialsHeading: content.deTestimonialsHeading || content.section3Title,
+    deTestimonials: unwrapTestimonials(content.deTestimonials || content.section1ReferenceList),
+    deVolunteerOpeningsHeading: content.deVolunteerOpeningsHeading || content.section2Title,
+    deVolunteerOpenings: (content.deVolunteerOpenings || content.volunteerOpenings)
+      .map(unwrapVolunteerOpening),
+    deVolunteerContactHeading: content.deVolunteerContactHeading || content.section1Title,
+    deVolunteerContactText: content.deVolunteerContactText || content.section1Markdown,
+    deVolunteerContact: unwrapTeamMember(content.deVolunteerContact || content.section1TeamMember),
+    saVolunteerOpening1Heading: content.saVolunteerOpening1Heading || content.section4Title,
+    saVolunteerOpening1Text: content.saVolunteerOpening1Text || content.section4Markdown,
+    saVolunteerOpening1ContactHeading: content.saVolunteerOpening1ContactHeading ||
+      content.section6Title,
+    saVolunteerOpening1ContactText: content.saVolunteerOpening1ContactText
+      || content.section6Markdown,
+    saVolunteerOpening1Contact: unwrapTeamMember(content.saVolunteerOpening1Contact
+      || content.section6TeamMember),
     saVolunteerOpening2Contact: unwrapTeamMember(content.saVolunteerOpening2Contact),
   }
 }

--- a/api/howToSupport.js
+++ b/api/howToSupport.js
@@ -50,6 +50,7 @@ export async function fetchBecomeAVolunteerPage(locale) {
     section1ReferenceList: unwrapTestimonials(content.section1ReferenceList),
     section5ReferenceList: unwrapTestimonials(content.section5ReferenceList),
     section6TeamMember: unwrapTeamMember(content.section6TeamMember),
+    saVolunteerOpening2Contact: unwrapTeamMember(content.saVolunteerOpening2Contact),
   }
 }
 

--- a/api/howToSupport.js
+++ b/api/howToSupport.js
@@ -49,7 +49,7 @@ export async function fetchBecomeAVolunteerPage(locale) {
     bannerButtonUrl: unwrapPageUrl(content.bannerButtonUrl),
     section1ReferenceList: unwrapTestimonials(content.section1ReferenceList),
     section5ReferenceList: unwrapTestimonials(content.section5ReferenceList),
-    section6TeamMember: unwrapTeamMember(content.section1TeamMember),
+    section6TeamMember: unwrapTeamMember(content.section6TeamMember),
   }
 }
 

--- a/components/TestimonialList/index.js
+++ b/components/TestimonialList/index.js
@@ -8,6 +8,11 @@ import { smBreakpoint } from '../../styling/breakpoints'
 import { mediumSpacing, extraSmallSpacing } from '../../styling/sizes'
 import Markdown from '../Markdown'
 
+const List = styled.div`
+  /* Counter bottom margin of TestimonialList in last line */
+  margin-bottom: -${mediumSpacing};
+`
+
 const TestimonialContainer = styled.div`
   margin-bottom: ${mediumSpacing};
 `
@@ -40,7 +45,7 @@ const TestimonialText = styled(Markdown)`
 `
 
 const TestimonialList = ({ testimonials, className }) => (
-  <div className={`row ${className}`}>
+  <List className={`row ${className}`}>
     {testimonials.map(({
       testimonialMarkdown, title, name, image,
     }) => (
@@ -58,7 +63,7 @@ const TestimonialList = ({ testimonials, className }) => (
         </div>
       </TestimonialContainer>
     ))}
-  </div>
+  </List>
 )
 
 TestimonialList.propTypes = {

--- a/pages/how-to-support/become-volunteer.js
+++ b/pages/how-to-support/become-volunteer.js
@@ -32,6 +32,11 @@ const BecomeVolunteer = ({
   section6Title,
   section6TeamMember,
   section6Markdown,
+  saVolunteerOpening2Heading,
+  saVolunteerOpening2Text,
+  saVolunteerOpening2ContactHeading,
+  saVolunteerOpening2ContactText,
+  saVolunteerOpening2Contact,
   bannerTitle,
   bannerButtonText,
   bannerButtonUrl,
@@ -89,6 +94,21 @@ const BecomeVolunteer = ({
       />
     </PageSection>
 
+    <PageSection>
+      <h2>{saVolunteerOpening2Heading}</h2>
+      <CenteredText source={saVolunteerOpening2Text} />
+    </PageSection>
+
+    <PageSection>
+      <TextWithTeamMember
+        header={saVolunteerOpening2ContactHeading}
+        text={saVolunteerOpening2ContactText}
+        teamMember={saVolunteerOpening2Contact}
+        teamMemberTitle={saVolunteerOpening2Contact.name}
+        teamMemberSubtitle={saVolunteerOpening2Contact.responsibilityArea}
+      />
+    </PageSection>
+
     <Banner
       headline={bannerTitle}
       buttonText={bannerButtonText}
@@ -118,6 +138,11 @@ BecomeVolunteer.propTypes = {
   section6TeamMember: PropTypes.shape(teamMemberProps).isRequired,
   section6Markdown: PropTypes.string.isRequired,
   section1ReferenceList: TestimonialList.propTypes.testimonials.isRequired,
+  saVolunteerOpening2Heading: PropTypes.string.isRequired,
+  saVolunteerOpening2Text: PropTypes.string.isRequired,
+  saVolunteerOpening2ContactHeading: PropTypes.string.isRequired,
+  saVolunteerOpening2ContactText: PropTypes.string.isRequired,
+  saVolunteerOpening2Contact: PropTypes.shape(teamMemberProps).isRequired,
   bannerTitle: PropTypes.string.isRequired,
   bannerButtonText: PropTypes.string.isRequired,
   bannerButtonUrl: PropTypes.string.isRequired,

--- a/pages/how-to-support/become-volunteer.js
+++ b/pages/how-to-support/become-volunteer.js
@@ -29,8 +29,6 @@ const BecomeVolunteer = ({
   volunteerOpenings,
   section4Title,
   section4Markdown,
-  section5Title,
-  section5ReferenceList,
   section6Title,
   section6TeamMember,
   section6Markdown,
@@ -82,11 +80,6 @@ const BecomeVolunteer = ({
     </PageSection>
 
     <PageSection>
-      <h2>{section5Title}</h2>
-      <TestimonialList testimonials={section5ReferenceList} />
-    </PageSection>
-
-    <PageSection>
       <TextWithTeamMember
         header={section6Title}
         text={section6Markdown}
@@ -121,8 +114,6 @@ BecomeVolunteer.propTypes = {
   volunteerOpenings: VolunteerOpeningsList.propTypes.volunteerOpenings.isRequired,
   section4Title: PropTypes.string.isRequired,
   section4Markdown: PropTypes.string.isRequired,
-  section5Title: PropTypes.string.isRequired,
-  section5ReferenceList: TestimonialList.propTypes.testimonials.isRequired,
   section6Title: PropTypes.string.isRequired,
   section6TeamMember: PropTypes.shape(teamMemberProps).isRequired,
   section6Markdown: PropTypes.string.isRequired,

--- a/pages/how-to-support/become-volunteer.js
+++ b/pages/how-to-support/become-volunteer.js
@@ -20,23 +20,26 @@ const BecomeVolunteer = ({
   metaDescription,
   introTitle,
   introMarkdown,
-  section1Title,
-  section1Markdown,
-  section1TeamMember,
-  section1ReferenceList,
-  section2Title,
-  section3Title,
-  volunteerOpenings,
-  section4Title,
-  section4Markdown,
-  section6Title,
-  section6TeamMember,
-  section6Markdown,
+
+  deTestimonialsHeading,
+  deTestimonials,
+  deVolunteerOpeningsHeading,
+  deVolunteerOpenings,
+  deVolunteerContactHeading,
+  deVolunteerContactText,
+  deVolunteerContact,
+
+  saVolunteerOpening1Heading,
+  saVolunteerOpening1Text,
+  saVolunteerOpening1ContactHeading,
+  saVolunteerOpening1ContactText,
+  saVolunteerOpening1Contact,
   saVolunteerOpening2Heading,
   saVolunteerOpening2Text,
   saVolunteerOpening2ContactHeading,
   saVolunteerOpening2ContactText,
   saVolunteerOpening2Contact,
+
   bannerTitle,
   bannerButtonText,
   bannerButtonUrl,
@@ -56,22 +59,22 @@ const BecomeVolunteer = ({
     </PageSection>
 
     <PageSection>
-      <h2>{section3Title}</h2>
-      <TestimonialList testimonials={section1ReferenceList} />
+      <h2>{deTestimonialsHeading}</h2>
+      <TestimonialList testimonials={deTestimonials} />
     </PageSection>
 
     <PageSection>
-      <h2>{section2Title}</h2>
-      <VolunteerOpeningsList volunteerOpenings={volunteerOpenings} />
+      <h2>{deVolunteerOpeningsHeading}</h2>
+      <VolunteerOpeningsList volunteerOpenings={deVolunteerOpenings} />
     </PageSection>
 
     <PageSection>
       <TextWithTeamMember
-        header={section1Title}
-        text={section1Markdown}
-        teamMember={section1TeamMember}
-        teamMemberTitle={section1TeamMember.name}
-        teamMemberSubtitle={section1TeamMember.responsibilityArea}
+        header={deVolunteerContactHeading}
+        text={deVolunteerContactText}
+        teamMember={deVolunteerContact}
+        teamMemberTitle={deVolunteerContact.name}
+        teamMemberSubtitle={deVolunteerContact.responsibilityArea}
       />
     </PageSection>
 
@@ -80,17 +83,17 @@ const BecomeVolunteer = ({
     </PageSection>
 
     <PageSection>
-      <h2>{section4Title}</h2>
-      <CenteredText source={section4Markdown} />
+      <h2>{saVolunteerOpening1Heading}</h2>
+      <CenteredText source={saVolunteerOpening1Text} />
     </PageSection>
 
     <PageSection>
       <TextWithTeamMember
-        header={section6Title}
-        text={section6Markdown}
-        teamMember={section6TeamMember}
-        teamMemberTitle={section6TeamMember.name}
-        teamMemberSubtitle={section6TeamMember.responsibilityArea}
+        header={saVolunteerOpening1ContactHeading}
+        text={saVolunteerOpening1ContactText}
+        teamMember={saVolunteerOpening1Contact}
+        teamMemberTitle={saVolunteerOpening1Contact.name}
+        teamMemberSubtitle={saVolunteerOpening1Contact.responsibilityArea}
       />
     </PageSection>
 
@@ -126,23 +129,26 @@ BecomeVolunteer.propTypes = {
   metaDescription: PropTypes.string,
   introTitle: PropTypes.string.isRequired,
   introMarkdown: PropTypes.string.isRequired,
-  section1Title: PropTypes.string.isRequired,
-  section1Markdown: PropTypes.string.isRequired,
-  section1TeamMember: PropTypes.shape(teamMemberProps).isRequired,
-  section2Title: PropTypes.string.isRequired,
-  section3Title: PropTypes.string.isRequired,
-  volunteerOpenings: VolunteerOpeningsList.propTypes.volunteerOpenings.isRequired,
-  section4Title: PropTypes.string.isRequired,
-  section4Markdown: PropTypes.string.isRequired,
-  section6Title: PropTypes.string.isRequired,
-  section6TeamMember: PropTypes.shape(teamMemberProps).isRequired,
-  section6Markdown: PropTypes.string.isRequired,
-  section1ReferenceList: TestimonialList.propTypes.testimonials.isRequired,
+
+  deVolunteerContactHeading: PropTypes.string.isRequired,
+  deVolunteerContactText: PropTypes.string.isRequired,
+  deVolunteerContact: PropTypes.shape(teamMemberProps).isRequired,
+  deVolunteerOpeningsHeading: PropTypes.string.isRequired,
+  deTestimonialsHeading: PropTypes.string.isRequired,
+  deTestimonials: TestimonialList.propTypes.testimonials.isRequired,
+  deVolunteerOpenings: VolunteerOpeningsList.propTypes.volunteerOpenings.isRequired,
+
+  saVolunteerOpening1Heading: PropTypes.string.isRequired,
+  saVolunteerOpening1Text: PropTypes.string.isRequired,
+  saVolunteerOpening1ContactHeading: PropTypes.string.isRequired,
+  saVolunteerOpening1ContactText: PropTypes.string.isRequired,
+  saVolunteerOpening1Contact: PropTypes.shape(teamMemberProps).isRequired,
   saVolunteerOpening2Heading: PropTypes.string.isRequired,
   saVolunteerOpening2Text: PropTypes.string.isRequired,
   saVolunteerOpening2ContactHeading: PropTypes.string.isRequired,
   saVolunteerOpening2ContactText: PropTypes.string.isRequired,
   saVolunteerOpening2Contact: PropTypes.shape(teamMemberProps).isRequired,
+
   bannerTitle: PropTypes.string.isRequired,
   bannerButtonText: PropTypes.string.isRequired,
   bannerButtonUrl: PropTypes.string.isRequired,

--- a/pages/how-to-support/become-volunteer.js
+++ b/pages/how-to-support/become-volunteer.js
@@ -51,13 +51,13 @@ const BecomeVolunteer = ({
     </PageSection>
 
     <PageSection>
-      <h2>{section2Title}</h2>
-      <VolunteerOpeningsList volunteerOpenings={volunteerOpenings} />
+      <h2>{section3Title}</h2>
+      <TestimonialList testimonials={section1ReferenceList} />
     </PageSection>
 
     <PageSection>
-      <h2>{section3Title}</h2>
-      <TestimonialList testimonials={section1ReferenceList} />
+      <h2>{section2Title}</h2>
+      <VolunteerOpeningsList volunteerOpenings={volunteerOpenings} />
     </PageSection>
 
     <PageSection>


### PR DESCRIPTION
As per Stefanie's feedback:

* Remove the SA Testimonials section
* Move up the DE Testimonials a bit
* Add a second set of SA volunteer opening sections (for internships)

I snuck in a change that allows us to give the Aktiv werden page meaningful field ID's without breaking stuff.