### PR TITLE
Expand the stat width with "flex: 1"

### DIFF
--- a/components/Stat.js
+++ b/components/Stat.js
@@ -10,10 +10,10 @@ const StatContainer = styled.div`
   display: flex;
   flex-direction: column;
   align-items: center;
-  
-  /* IE11 fix */
-  flex-shrink: 1;
+
+  flex: 1;
   flex-basis: auto;
+
   @media(min-width: ${smBreakpoint}) {
     flex-basis: 0;
   }


### PR DESCRIPTION
This also seems to remove the need for the IE11 fix in the code (works fine in IE).

![screen shot 2018-02-27 at 17 32 40](https://user-images.githubusercontent.com/1032624/36740976-40d665d0-1be4-11e8-86d9-8852e98c3cd8.png)
