### PR TITLE
Redirect from masifunde.netlify.com to masifunde.de website

### DIFF
--- a/public/common/_redirects
+++ b/public/common/_redirects
@@ -1,3 +1,7 @@
+# Redirect from masifunde.netlify.com to masifunde.de
+http://masifunde.netlify.com/* https://www.masifunde.de/:splat 301!
+https://masifunde.netlify.com/* https://www.masifunde.de/:splat 301!
+
 # Redirects
 /ueber-uns/news-archiv/news/:slug /blog/:slug
 /ueber-uns/* /wer-wir-sind


### PR DESCRIPTION
Redirect from masifunde.netlify.com to masifunde.de website with status code 301. The reason for this is that it is better to avoid duplicate content on the web.

This should be **merged** only when the HTTPS is working.