### PR TITLE
Switch sitemap URLs to HTTPS

### DIFF
--- a/utils/sitemap.js
+++ b/utils/sitemap.js
@@ -45,7 +45,7 @@ function createSitemap(routes) {
     }))
 
   const sitemap = sm.createSitemap({
-    hostname: 'http://www.masifunde.de',
+    hostname: 'https://www.masifunde.de',
     urls,
   })
 


### PR DESCRIPTION
Since we fixed the HTTPS on masifunde.de domain we also forced the HTTPS. So the website will now automatically switch to HTTPS all of the time for all of the users.

That's why it makes sense to update the sitemap URLs to use HTTPS.