### PR TITLE
Fix double padding when using ContainedGrid and PageSection

### DIFF
--- a/components/CenteredGrid.js
+++ b/components/CenteredGrid.js
@@ -1,7 +1,7 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 
-const ContainedGrid = ({
+const CenteredGrid = ({
   children,
   className,
   withoutContainer,
@@ -15,15 +15,15 @@ const ContainedGrid = ({
   </div>
 )
 
-ContainedGrid.propTypes = {
+CenteredGrid.propTypes = {
   children: PropTypes.node.isRequired,
   className: PropTypes.string,
   withoutContainer: PropTypes.bool,
 }
 
-ContainedGrid.defaultProps = {
+CenteredGrid.defaultProps = {
   className: '',
   withoutContainer: false,
 }
 
-export default ContainedGrid
+export default CenteredGrid

--- a/components/ContainedGrid.js
+++ b/components/ContainedGrid.js
@@ -1,8 +1,12 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 
-const ContainedGrid = ({ children }) => (
-  <div className="container">
+const ContainedGrid = ({
+  children,
+  className,
+  withoutContainer,
+}) => (
+  <div className={`${className} ${withoutContainer ? '' : 'container'}`}>
     <div className="row">
       <div className="offset-lg-1 col-lg-10">
         {children}
@@ -13,6 +17,13 @@ const ContainedGrid = ({ children }) => (
 
 ContainedGrid.propTypes = {
   children: PropTypes.node.isRequired,
+  className: PropTypes.string,
+  withoutContainer: PropTypes.bool,
+}
+
+ContainedGrid.defaultProps = {
+  className: '',
+  withoutContainer: false,
 }
 
 export default ContainedGrid

--- a/pages/campaign/index.js
+++ b/pages/campaign/index.js
@@ -16,6 +16,7 @@ import withQueryParams from '../../components/withQueryParams'
 import DonationForm from '../../components/DonationForm'
 import imagePropTypes from '../../propTypes/image'
 import teamMemmberPropTypes from '../../propTypes/teamMember'
+import ContainedGrid from '../../components/ContainedGrid'
 
 const StyledRoundedImage = RoundedImage.extend`
   margin-bottom: 1rem;
@@ -50,40 +51,36 @@ const Campaign = ({
       <CenteredText source={introMarkdown} />
     </PageSection>
 
-    <div className="container">
-      <div className="row">
-        <div className="offset-lg-1 col-lg-10">
-          <PageSection>
-            <div className="row">
-              <div className="col-md">
-                {imageList.map(({ url, title }) => (
-                  <StyledRoundedImage
-                    className="img-fluid"
-                    key={url}
-                    src={url}
-                    alt={title}
-                  />
-                ))}
-              </div>
-              <div className="col-md">
-                <Markdown source={contentMarkdown} />
-              </div>
-            </div>
-          </PageSection>
-
-          <PageSection>
-            <TeamMemberHeadline>{teamMemberHeading}</TeamMemberHeadline>
-            <div>
-              <TeamMember
-                imageUrl={teamMember.image.url}
-                title={teamMember.name}
-                email={teamMember.email}
+    <ContainedGrid>
+      <PageSection contained={false}>
+        <div className="row">
+          <div className="col-md">
+            {imageList.map(({ url, title }) => (
+              <StyledRoundedImage
+                className="img-fluid"
+                key={url}
+                src={url}
+                alt={title}
               />
-            </div>
-          </PageSection>
+            ))}
+          </div>
+          <div className="col-md">
+            <Markdown source={contentMarkdown} />
+          </div>
         </div>
-      </div>
-    </div>
+      </PageSection>
+
+      <PageSection contained={false}>
+        <TeamMemberHeadline>{teamMemberHeading}</TeamMemberHeadline>
+        <div>
+          <TeamMember
+            imageUrl={teamMember.image.url}
+            title={teamMember.name}
+            email={teamMember.email}
+          />
+        </div>
+      </PageSection>
+    </ContainedGrid>
 
     <DonationForm
       amounts={amounts}

--- a/pages/campaign/index.js
+++ b/pages/campaign/index.js
@@ -16,7 +16,7 @@ import withQueryParams from '../../components/withQueryParams'
 import DonationForm from '../../components/DonationForm'
 import imagePropTypes from '../../propTypes/image'
 import teamMemmberPropTypes from '../../propTypes/teamMember'
-import ContainedGrid from '../../components/ContainedGrid'
+import CenteredGrid from '../../components/CenteredGrid'
 
 const StyledRoundedImage = RoundedImage.extend`
   margin-bottom: 1rem;
@@ -51,7 +51,7 @@ const Campaign = ({
       <CenteredText source={introMarkdown} />
     </PageSection>
 
-    <ContainedGrid>
+    <CenteredGrid>
       <PageSection contained={false}>
         <div className="row">
           <div className="col-md">
@@ -80,7 +80,7 @@ const Campaign = ({
           />
         </div>
       </PageSection>
-    </ContainedGrid>
+    </CenteredGrid>
 
     <DonationForm
       amounts={amounts}

--- a/pages/documents/index.js
+++ b/pages/documents/index.js
@@ -5,7 +5,7 @@ import PropTypes from 'prop-types'
 import withLayout from '../../components/withLayout'
 import DocumentsList from '../../components/DocumentsList'
 import PageSection from '../../components/PageSection'
-import ContainedGrid from '../../components/ContainedGrid'
+import CenteredGrid from '../../components/CenteredGrid'
 import CenteredText from '../../components/CenteredText'
 import Divider from '../../components/Divider'
 import Banner from '../../components/Banner'
@@ -66,7 +66,7 @@ const Documents = ({
       <CenteredText source={introMarkdown} />
     </PageSection>
 
-    <ContainedGrid>
+    <CenteredGrid>
       <PageSection contained={false}>
         <Heading>{section1heading}</Heading>
         <DocumentsList documents={documentsList1} />
@@ -84,7 +84,7 @@ const Documents = ({
 
         <ExtendedDivider color="orange" />
       </PageSection>
-    </ContainedGrid>
+    </CenteredGrid>
 
     <PageSection>
       <TeamMemberContainer>

--- a/pages/who-we-are/index.js
+++ b/pages/who-we-are/index.js
@@ -140,7 +140,7 @@ const WhoWeAre = ({
       <PageSection>
         <h2>{patronsHeadline}</h2>
         <PatronsText source={patronsText} />
-        <ContainedGrid>
+        <ContainedGrid withoutContainer>
           <TestimonialList testimonials={patronsList} />
         </ContainedGrid>
       </PageSection>

--- a/pages/who-we-are/index.js
+++ b/pages/who-we-are/index.js
@@ -20,7 +20,7 @@ import { lgBreakpoint } from '../../styling/breakpoints'
 import Link from '../../components/Link'
 import featureFlags from '../../featureFlags'
 import TestimonialList from '../../components/TestimonialList'
-import ContainedGrid from '../../components/ContainedGrid'
+import CenteredGrid from '../../components/CenteredGrid'
 
 const Image = styled.img`
   width: 100%;
@@ -140,9 +140,9 @@ const WhoWeAre = ({
       <PageSection>
         <h2>{patronsHeadline}</h2>
         <PatronsText source={patronsText} />
-        <ContainedGrid withoutContainer>
+        <CenteredGrid withoutContainer>
           <TestimonialList testimonials={patronsList} />
-        </ContainedGrid>
+        </CenteredGrid>
       </PageSection>
     )}
 


### PR DESCRIPTION
If the `container` classes gets nested it will multiply the padding on left and right. This is especially visible on small devices.