### PR TITLE
Change default locale to German

### DIFF
--- a/api/blog.js
+++ b/api/blog.js
@@ -48,22 +48,22 @@ function fetchBlogPostPageTemplate(locale) {
   return fetchSingleEntry('pageBlogPost', locale)
 }
 
+
 async function fetchPreviousBlogPostSlug(locale, date) {
-  let entries = await fetchEntriesForContentType('blogPost', {
+  const fetchParams = {
     locale,
     limit: 1,
     order: '-fields.date',
     'fields.date[lt]': date,
     'fields.slug[exists]': true,
-  })
+  }
+
+  let entries = await fetchEntriesForContentType('blogPost', fetchParams)
 
   if (entries.length === 0) {
     entries = await fetchEntriesForContentType('blogPost', {
+      ...fetchParams,
       locale: 'de',
-      limit: 1,
-      order: '-fields.date',
-      'fields.date[lt]': date,
-      'fields.slug[exists]': true,
     })
   }
 
@@ -71,21 +71,20 @@ async function fetchPreviousBlogPostSlug(locale, date) {
 }
 
 async function fetchNextBlogPostSlug(locale, date) {
-  let entries = await fetchEntriesForContentType('blogPost', {
+  const fetchParams = {
     locale,
     limit: 1,
     order: 'fields.date',
     'fields.date[gt]': date,
     'fields.slug[exists]': true,
-  })
+  }
+
+  let entries = await fetchEntriesForContentType('blogPost', fetchParams)
 
   if (entries.length === 0) {
     entries = await fetchEntriesForContentType('blogPost', {
+      ...fetchParams,
       locale: 'de',
-      limit: 1,
-      order: 'fields.date',
-      'fields.date[gt]': date,
-      'fields.slug[exists]': true,
     })
   }
 

--- a/env.js
+++ b/env.js
@@ -1,9 +1,18 @@
+const featureFlags = require('./featureFlags')
+
+const spaceId = featureFlags.release10
+  ? '7wl9zvp70267'
+  : '6jocdllnp50q'
+
+const accessToken = featureFlags.release10
+  ? '0afa27121adcd096d9046e06f1e23983af0b2816f4f57380a55ae6359d1b1ce3'
+  : '5c8090d12bc2bf8dc695353cc398cd5e48eb56c214325884284bfdbfef4ba5ed'
+
 module.exports = {
   // Contentful
-  CONTENTFUL_SPACE_ID: process.env.CONTENTFUL_SPACE_ID || '6jocdllnp50q',
+  CONTENTFUL_SPACE_ID: process.env.CONTENTFUL_SPACE_ID || spaceId,
   CONTENTFUL_HOST: process.env.CONTENTFUL_HOST || undefined,
-  CONTENTFUL_ACCESS_TOKEN: process.env.CONTENTFUL_ACCESS_TOKEN ||
-    '5c8090d12bc2bf8dc695353cc398cd5e48eb56c214325884284bfdbfef4ba5ed',
+  CONTENTFUL_ACCESS_TOKEN: process.env.CONTENTFUL_ACCESS_TOKEN || accessToken,
 
   // Google Analytics
   GOOGLE_ANALYTICS_ID: process.env.GOOGLE_ANALYTICS_ID || undefined,

--- a/next.config.js
+++ b/next.config.js
@@ -106,7 +106,7 @@ async function blogPostsPathMap() {
 
   for (let n = 1; n <= numPages; n += 1) {
     locales.forEach((locale) => {
-      const path = putLocale(`/blog/page/${n}`, locale)
+      const path = putLocale(`/:locale?/blog/page/${n}`, locale)
       pathMap[path] = {
         page: Routes.RouteNames.Blog,
         query: {

--- a/utils/changeDefaultLocale.js
+++ b/utils/changeDefaultLocale.js
@@ -1,0 +1,47 @@
+// This script was used for changing the default locale from English to German
+// for the Contentful CMS by exporting the old content, fiddling with the JSON
+// to change the locale, and then import the output. It's not production
+// quality code, just a quick hack. But I committed it just in case.
+//
+// The export/import process is described here:
+//
+// https://www.contentful.com/developers/docs/tutorials/general/import-and-export/
+//
+// After exporting the file, the first step was to manually edit the locales
+// section of the JSON to switch the default. Then run this script to update
+// all entries and assets that only have an en locale to have a de locale
+// instead. That was enough to allow an import of the data into a new Contentful
+// space with German set as the default locale.
+
+/* eslint-disable */
+
+const exportFile = process.argv[2]
+
+const json = require(exportFile)
+
+function changeFields(fields) {
+  Object.keys(fields).forEach((k) => {
+    const f = fields[k]
+    if ('en' in f && !('de' in f)) {
+      f.de = f.en
+      delete f.en
+      return f
+    }
+    fields[k] = f
+  })
+  return fields
+}
+
+json.entries = json.entries.map((e) => {
+  const newFields = changeFields(e.fields)
+  return { ...e, fields: newFields }
+})
+
+
+json.assets = json.assets.map((a) => {
+  const newFields = changeFields(a.fields)
+  return { ...a, fields: newFields }
+})
+
+
+console.log(JSON.stringify(json, null, 2))

--- a/utils/replaceLocale.js
+++ b/utils/replaceLocale.js
@@ -1,0 +1,7 @@
+function replaceLocale(pattern, locale) {
+  const localePrefix = locale === 'de' ? '' : `/${locale}`
+  const patternWithLocale = pattern.replace(/\/:locale[^/]*/, localePrefix)
+  return patternWithLocale || '/'
+}
+
+module.exports = replaceLocale


### PR DESCRIPTION
This PR started as me trying to fix German blog posts not showing up on the English version of the site. The obvious fix would be to change the default locale in Contentful, but that's not actually possible for a CMS with data in it.

I tried a few hacks, but it was uglier than I was prepared to put ip with, and after discussing it with Karl, we thought the best approach would be to create a new Contentful space, with the locale set correctly, and then export the data from the old space and import it into the new space.

This didn't work immediately either, the JSON needed some massaging to switch certain entries over from "en" to "de", but once I'd written a script to do that, the data imported into the new space.

This PR switches over to the new space, and adds fixes for the blog post locale fallback both for dynamic fetches and static exports.