### PR TITLE
Skip unpublished documents on Documents & Press pages

### DIFF
--- a/api/document.js
+++ b/api/document.js
@@ -1,22 +1,24 @@
 import { fetchSingleEntry } from './contentfulService'
 import {
+  isUnresolvedLink,
   unwrapFields,
-  unwrapFiles,
+  unwrapDocuments,
   unwrapTeamMember,
 } from './common'
 
-const unwrapVideos = (videos = []) => videos.map(unwrapFields)
+const unwrapVideos = (videos = []) =>
+  videos.filter((video) => !isUnresolvedLink(video)).map(unwrapFields)
 
 export async function fetchDocumentPage(locale) {
   const content = await fetchSingleEntry('pageDokumente', locale)
   return {
     ...content,
     teamMember: unwrapTeamMember(content.teamMember),
-    documentsList1: unwrapFiles(content.documentsList1),
-    documentsList2: unwrapFiles(content.documentsList2),
-    documentsList3: unwrapFiles(content.documentsList3),
+    documentsList1: unwrapDocuments(content.documentsList1 || []),
+    documentsList2: unwrapDocuments(content.documentsList2 || []),
+    documentsList3: unwrapDocuments(content.documentsList3 || []),
     videosList: unwrapVideos(content.videosList),
-    pressKitList: unwrapFiles(content.pressKitList),
-    pressReleaseList: unwrapFiles(content.pressReleaseList),
+    pressKitList: unwrapDocuments(content.pressKitList || []),
+    pressReleaseList: unwrapDocuments(content.pressReleaseList || []),
   }
 }

--- a/api/press.js
+++ b/api/press.js
@@ -1,9 +1,5 @@
 import { fetchSingleEntry } from './contentfulService'
-import {
-  unwrapFields,
-  unwrapFiles,
-  unwrapTeamMember,
-} from './common'
+import { unwrapFields, unwrapDocuments, unwrapTeamMember } from './common'
 
 const unwrapVideos = (videos = []) => videos.map(unwrapFields)
 
@@ -11,9 +7,9 @@ export async function fetchPressPage(locale) {
   const content = await fetchSingleEntry('pagePress', locale)
   return {
     ...content,
-    videosList: unwrapVideos(content.videosList),
-    documentsList1: unwrapFiles(content.documentsList1),
-    documentsList2: unwrapFiles(content.documentsList2),
+    videosList: unwrapVideos(content.videosList || []),
+    documentsList1: unwrapDocuments(content.documentsList1 || []),
+    documentsList2: unwrapDocuments(content.documentsList2 || []),
     teamMember: unwrapTeamMember(content.teamMember),
   }
 }


### PR DESCRIPTION
If a document referred to by the Documents or Press page is not published (e.g., archived), then the Content Delivery API will return it as an entry of type `Link` without a `fields` property. Skip such entries instead of breaking during rendering.