### PR TITLE
Fix broken cookie accept button

### DIFF
--- a/src/components/CookieNotice.js
+++ b/src/components/CookieNotice.js
@@ -50,11 +50,11 @@ const Buttons = styled.div`
   }
 `
 
-const PrivacyPolicyButton = styled(Button).attrs({ type: 'banner' })`
+const PrivacyPolicyButton = styled(Button)`
   white-space: nowrap;
 `
 
-const AcceptButton = styled(Button).attrs({ type: 'banner' })`
+const AcceptButton = styled(Button)`
   margin-left: ${extraExtraSmallSpacing};
   white-space: nowrap;
 `
@@ -92,7 +92,7 @@ export default class CookieNotice extends Component {
               {T.translate('cookieNotice.privacyPolicy')}
             </PrivacyPolicyButton>
           </Link>
-          <AcceptButton onClick={this.handleAccept}>
+          <AcceptButton variant="banner" onClick={this.handleAccept}>
             {T.translate('cookieNotice.accept')}
           </AcceptButton>
         </Buttons>

--- a/src/components/shared/Button.tsx
+++ b/src/components/shared/Button.tsx
@@ -16,6 +16,7 @@ export type Props = {
   rel?: string
   rounded?: boolean
   isActive?: boolean
+  onClick?: () => void
 }
 
 // Helpers
@@ -32,6 +33,7 @@ const CoreButton: FC<Props> = ({
   className,
   href,
   rel,
+  onClick,
 }) => {
   return (
     <ButtonContainer center={center}>
@@ -40,7 +42,9 @@ const CoreButton: FC<Props> = ({
           {children}
         </a>
       ) : (
-        <button className={`btn ${className}`}>{children}</button>
+        <button className={`btn ${className}`} onClick={onClick}>
+          {children}
+        </button>
       )}
     </ButtonContainer>
   )


### PR DESCRIPTION
Heeeeyyy! 😃 👋 🎉 

I visited www.masifunde.de for old times' sake and saw that the cookie accept button was broken. When you rewrote the buttons to Typescript it seems like it broke after the props spreading was removed here https://github.com/futurice/masifunde-fe/commit/1b5ddc31487e065158ce7fd6f740424561362457#diff-bca960114d989aae0a5da8b37c4a91cd15bf76058f0e0d5340317ddcbca861daL24 . Additionally the `PrivacyPolicyButton` and `AcceptButton` tried using `type` instead of `variant`, so the accept button had the wrong color.

Cool to see that this is still being maintained, hope you're doing well! 😃 

Production right now ("OK" button in the cookie notice is red and does not work):
![image](https://user-images.githubusercontent.com/3830142/211996983-5c71a913-61d8-430b-9fa4-5616d8b211d5.png)

With my fix:
![image](https://user-images.githubusercontent.com/3830142/211997082-3ce43750-2b9a-4975-9c46-83e0f3e915a7.png)